### PR TITLE
fix: ignore duplicate projectile contacts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-12
+
+- Prevented duplicate queued projectile contacts from scoring after either
+  collision node has already left the active scene.
+
 ## 2026-06-10
 
 - Migrated the SpriteKit target from Swift 3 to Swift 5.

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -265,11 +265,12 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     //MARK: - Projectile Collision Actions
     func projectileDidCollideWithMonster(_ projectile:SKSpriteNode, monster:SKSpriteNode) {
         if gameIsOver { return }
+        guard projectile.parent === self, monster.parent === self else { return }
 
-        monstersDestroyed += 1
-        scoreLabel.text = "Score: \(monstersDestroyed)"
         projectile.removeFromParent()
         monster.removeFromParent()
+        monstersDestroyed += 1
+        scoreLabel.text = "Score: \(monstersDestroyed)"
         
         // check timer and if end then show end
         

--- a/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
+++ b/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
@@ -1,0 +1,26 @@
+# Projectile Duplicate Contact Guard
+
+status: planned
+
+## Context
+
+SpriteKit may deliver multiple queued contacts involving the same projectile in
+one physics step. `projectileDidCollideWithMonster` increments score before
+checking whether the projectile or monster was already removed, so one shot can
+score more than once when contacts overlap.
+
+## Scope
+
+- Require both collision nodes to remain attached to the active scene before
+  mutating score.
+- Remove the nodes before incrementing and rendering the score.
+- Preserve the existing game-over guard and 20-hit win threshold.
+- Extend the static baseline with node-lifecycle ordering contracts.
+
+## Verification
+
+- `make check`
+- `git diff --check`
+- Mutations removing the active-node guard or moving score mutation before node
+  removal must fail the baseline.
+- Hosted macOS validation must build the Swift 5 SpriteKit sample.

--- a/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
+++ b/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
@@ -1,6 +1,6 @@
 # Projectile Duplicate Contact Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -9,7 +9,7 @@ one physics step. `projectileDidCollideWithMonster` increments score before
 checking whether the projectile or monster was already removed, so one shot can
 score more than once when contacts overlap.
 
-## Scope
+## Completed Scope
 
 - Require both collision nodes to remain attached to the active scene before
   mutating score.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,6 +23,7 @@ GAME_OVER_RESTART_PLAN = ROOT / "docs/plans/2026-06-10-game-over-restart-guard.m
 CI_PLAN = ROOT / "docs/plans/2026-06-10-ci-baseline.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
+DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -136,6 +137,7 @@ def main():
         "docs/plans/2026-06-10-ci-baseline.md",
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-swift-5-spritekit-build.md",
+        "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
         "docs/readme-overview.svg",
     ]
 
@@ -186,6 +188,7 @@ def main():
     ci_plan = CI_PLAN.read_text(encoding="utf-8") if CI_PLAN.exists() else ""
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     swift_5_build_plan = SWIFT_5_BUILD_PLAN.read_text(encoding="utf-8") if SWIFT_5_BUILD_PLAN.exists() else ""
+    duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -279,10 +282,18 @@ def main():
             failures)
     projectile_collision_index = game_scene.find("func projectileDidCollideWithMonster")
     projectile_guard_index = game_scene.find("if gameIsOver { return }", projectile_collision_index)
+    projectile_active_node_guard_index = game_scene.find("guard projectile.parent === self, monster.parent === self else { return }", projectile_collision_index)
+    projectile_remove_index = game_scene.find("projectile.removeFromParent()", projectile_collision_index)
+    monster_remove_index = game_scene.find("monster.removeFromParent()", projectile_collision_index)
     projectile_score_index = game_scene.find("monstersDestroyed += 1", projectile_collision_index)
     require(projectile_collision_index != -1 and projectile_guard_index != -1 and
             projectile_score_index != -1 and projectile_guard_index < projectile_score_index,
             "Projectile collision handler must ignore late contacts before mutating score",
+            failures)
+    require(projectile_active_node_guard_index != -1 and
+            projectile_guard_index < projectile_active_node_guard_index < projectile_remove_index and
+            projectile_remove_index < projectile_score_index and monster_remove_index < projectile_score_index,
+            "Projectile collisions must require active nodes and remove them before mutating score",
             failures)
     player_collision_index = game_scene.find("func monsterDidCollideWithPlayer")
     player_guard_index = game_scene.find("if gameIsOver { return }", player_collision_index)
@@ -391,6 +402,9 @@ def main():
             failures)
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
+            failures)
+    require("status: completed" in duplicate_contact_plan and "mutations" in duplicate_contact_plan.lower(),
+            "duplicate projectile contact plan must record completed mutation verification",
             failures)
     workflow_files = sorted(
         str(path.relative_to(ROOT))


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: ignore duplicate projectile contacts

### Original Description

### Summary

- require projectile and monster nodes to remain attached to the active scene
- remove collision nodes before incrementing and rendering score
- prevent queued duplicate SpriteKit contacts from scoring one shot twice
- preserve the existing game-over guard and 20-hit win threshold

## Verification

- `make check`
- `git diff --check`
- active-node guard mutation rejected
- score-order mutation rejected

Hosted macOS validation compiles the Swift 5 SpriteKit target for the simulator.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the SpriteKit gameplay safety, resource integrity, configuration security, build, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted evidence is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, game resource, secret-scanning resolution, or runtime behavior.

## Follow-Ups

The open historical Google API key alert remains unresolved and must be independently revoked or verified before this repository can be marked complete.
