### PR TITLE
Document projectile guard verification

### DIFF
--- a/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
+++ b/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
@@ -9,7 +9,7 @@ one physics step. `projectileDidCollideWithMonster` increments score before
 checking whether the projectile or monster was already removed, so one shot can
 score more than once when contacts overlap.
 
-## Completed Scope
+## Work Completed
 
 - Require both collision nodes to remain attached to the active scene before
   mutating score.
@@ -17,10 +17,25 @@ score more than once when contacts overlap.
 - Preserve the existing game-over guard and 20-hit win threshold.
 - Extend the static baseline with node-lifecycle ordering contracts.
 
-## Verification
+## Verification Completed
 
-- `make check`
-- `git diff --check`
-- Mutations removing the active-node guard or moving score mutation before node
-  removal must fail the baseline.
-- Hosted macOS validation must build the Swift 5 SpriteKit sample.
+- Local `make check`, `make lint`, `make test`, and `make build` passed. The
+  local environment did not provide `xcodebuild`, so these runs exercised the
+  complete static baseline and reported the hosted Xcode requirement.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Hostile mutations changing the plan status, inserting an unfinished-work
+  marker, falsifying a run ID, removing the active-node predicate, or moving
+  score mutation before node removal were rejected by the baseline.
+- The implementation push Check run `27394998651` completed successfully for
+  commit `560e645d46cd073f7d062719c486e022e0d79611`.
+- The implementation pull-request Check run `27395002711` completed
+  successfully for commit `560e645d46cd073f7d062719c486e022e0d79611` and
+  built the Swift 5 SpriteKit sample on hosted macOS.
+- The post-merge push Check run `27395075194` completed successfully for
+  commit `8ce9716ffb4a523612fad6a401a326b2d17b22ac`.
+- The CodeQL setup run `27402323210` completed successfully for commit
+  `8ce9716ffb4a523612fad6a401a326b2d17b22ac`.
+- The collision handler preserves
+  `guard projectile.parent === self, monster.parent === self else { return }`
+  and removes both nodes before `monstersDestroyed += 1`.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -61,6 +61,14 @@ def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
 def strip_swift_line_comments(text):
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
 
@@ -403,9 +411,39 @@ def main():
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
             failures)
-    require("status: completed" in duplicate_contact_plan and "mutations" in duplicate_contact_plan.lower(),
-            "duplicate projectile contact plan must record completed mutation verification",
+    duplicate_contact_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan
+    )
+    duplicate_contact_work = markdown_section(duplicate_contact_plan, "Work Completed")
+    duplicate_contact_verification = markdown_section(
+        duplicate_contact_plan, "Verification Completed"
+    )
+    require(duplicate_contact_status == ["completed"] and duplicate_contact_work,
+            "duplicate projectile contact plan must record one completed status and completed work",
             failures)
+    require(duplicate_contact_verification and
+            not re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", duplicate_contact_verification),
+            "duplicate projectile contact plan must record finished verification without pending markers",
+            failures)
+    for evidence in [
+        "make check",
+        "make lint",
+        "make test",
+        "make build",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "git diff --check",
+        "27394998651",
+        "27395002711",
+        "27395075194",
+        "27402323210",
+        "560e645d46cd073f7d062719c486e022e0d79611",
+        "8ce9716ffb4a523612fad6a401a326b2d17b22ac",
+        "guard projectile.parent === self, monster.parent === self else { return }",
+        "monstersDestroyed += 1",
+    ]:
+        require(evidence in duplicate_contact_verification,
+                f"duplicate projectile contact plan must preserve verification evidence: {evidence}",
+                failures)
     workflow_files = sorted(
         str(path.relative_to(ROOT))
         for path in (ROOT / ".github/workflows").rglob("*")


### PR DESCRIPTION
## Summary
Document the completed duplicate-projectile-contact guard with exact hosted evidence and enforce that evidence in the canonical baseline.

## Baseline
The merged implementation already rejects detached projectile or monster nodes and removes both nodes before incrementing score. Historical push, pull-request, post-merge, and CodeQL runs are successful.

## Improvements
- Record exact run IDs and commit SHAs in the completed plan.
- Require one completed status and a finished verification section.
- Preserve the active-node predicate and remove-before-score ordering.
- Reject five hostile plan and source mutations.

## Validation
- `make check`
- `make lint`
- `make test`
- `make build`
- `python3 -m py_compile scripts/check-baseline.py`
- `git diff --check`
- Five hostile mutations rejected

## Risk
Local Linux cannot run Xcode. The canonical hosted macOS Check builds the Swift 5 SpriteKit sample; this documentation-only follow-up does not change runtime behavior.

## Follow-Ups
Keep PR #5 open for owner review. Do not merge without explicit authorization, and require exact-head push, pull-request, and CodeQL success.