### PR TITLE
Guard monster spawning in undersized scenes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Skipped enemy spawning for invalid or undersized scene geometry before
+  constructing a closed random range or adding the SpriteKit node.
+
 ## 2026-06-12
 
 - Prevented duplicate queued projectile contacts from scoring after either

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -101,6 +101,20 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     func random(min: CGFloat, max: CGFloat) -> CGFloat {
         return CGFloat.random(in: min...max)
     }
+
+    func monsterSpawnY(spriteHeight: CGFloat) -> CGFloat? {
+        guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else {
+            return nil
+        }
+
+        let minY = spriteHeight / 2
+        let maxY = size.height - minY
+        guard minY <= maxY else {
+            return nil
+        }
+
+        return random(min: minY, max: maxY)
+    }
     
     //MARK: - Get Profile Picture
     func roundSquareImage(imageName: String) -> SKSpriteNode {
@@ -140,7 +154,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         
         // Determine where to spawn the monster along the Y axis
-        let actualY = random(min: monster.size.height/2, max: size.height - monster.size.height/2)
+        guard let actualY = monsterSpawnY(spriteHeight: monster.size.height) else {
+            return
+        }
         
         // Position the monster slightly off-screen along the right edge,
         // and along a random position along the Y axis as calculated above

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Debug logging from launch and gameplay paths should stay removed; score should remain visible in-game rather than printed to the console.
 - Runtime debug overlays should stay disabled outside explicit troubleshooting builds.
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.
+- Enemy spawning skips invalid or undersized scene geometry before constructing
+  a random range or adding a SpriteKit node.
 
 ## Maintenance Notes
 
@@ -118,6 +120,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-09-collision-handler-game-over-guard.md` for the collision handler guardrail.
 - See `docs/plans/2026-06-09-contact-delegate-game-over-guard.md` for the contact delegate game-over guardrail.
 - See `docs/plans/2026-06-10-game-over-restart-guard.md` for the game-over restart guardrail.
+- See `docs/plans/2026-06-13-undersized-scene-spawn-guard.md` for the enemy
+  spawn geometry guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
-- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,8 @@ Priority:
 - Keep collision handlers from mutating score or player state after game over
 - Clear the physics contact delegate before game-over scene transitions
 - Stop enemy spawning as soon as game-over presentation starts
+- Skip enemy spawning when invalid or undersized scene geometry cannot contain
+  the monster sprite
 - Keep background scroll movement running per-frame until game over
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode
@@ -65,7 +67,7 @@ Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 metadata, bundled resource references, SpriteKit scene sources, image helper
 fallbacks, game-over transition guards, game-over restart handling, collision
 handler game-over guards, contact delegate cleanup, spawn lifecycle guards,
-per-frame background scroll movement, and local-only gameplay with no debug
+undersized scene spawn geometry, per-frame background scroll movement, and local-only gameplay with no debug
 logging, network, analytics, upload, or persistence behavior.
 On macOS, the baseline should compile an unsigned simulator build without
 rendering frames, playing audio, simulating physics, or running gameplay.

--- a/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
+++ b/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
@@ -1,0 +1,67 @@
+# Undersized Scene Spawn Guard
+
+status: planned
+
+## Context
+
+`addMonster()` builds a closed random Y range from half the monster height to
+the scene height minus half the monster height. If the SpriteKit scene is
+temporarily smaller than the sprite, that range is inverted and
+`CGFloat.random(in:)` traps before the spawn can be skipped.
+
+## Priority
+
+Scene dimensions can be transient during presentation, resizing, previews, or
+future tests. Enemy scheduling should tolerate an unusable layout frame without
+crashing the local game loop.
+
+## Requirements
+
+- R1. Calculate monster spawn Y through one helper that returns an optional.
+- R2. Reject non-finite scene or sprite heights, non-positive sprite height, and
+  scenes shorter than the sprite before constructing a random range.
+- R3. `addMonster()` must return before adding a node, physics, movement, or
+  sound when no valid Y position exists.
+- R4. Valid scenes must preserve the existing uniform closed-range placement.
+- R5. Preserve game-over spawn guards, spawn action keys, speed range, physics,
+  scoring, contacts, transitions, assets, and local-only behavior.
+- R6. Add method-scoped static contracts and completed verification evidence.
+
+## Implementation Units
+
+### U1. Validate vertical spawn geometry
+
+- **File:** `EmojiThrower/GameScene.swift`
+- Add an optional spawn-Y helper and guard its result before node insertion.
+
+### U2. Enforce crash-safe ordering
+
+- **File:** `scripts/check-baseline.py`
+- Require finite and positive inputs, ordered range validation, optional return,
+  and guard-before-`addChild` placement.
+
+### U3. Document the SpriteKit boundary
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record that undersized or invalid scenes skip enemy spawning.
+
+## Scope Boundaries
+
+- Do not change normal scene dimensions, monster assets, speed, cadence,
+  collision masks, score thresholds, or game-over behavior.
+- Do not add persistence, telemetry, networking, analytics, or a new test target.
+- Do not claim interactive gameplay validation without Xcode.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- Parse plist, storyboard, workspace, project, and workflow metadata with all
+  available local parsers.
+- `git diff --check`
+- Hostile mutations removing finite, positive, or ordered-range validation,
+  optional failure, guard-before-add ordering, plan status, or verification
+  evidence must be rejected.

--- a/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
+++ b/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
@@ -1,6 +1,6 @@
 # Undersized Scene Spawn Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -52,16 +52,24 @@ crashing the local game loop.
 - Do not add persistence, telemetry, networking, analytics, or a new test target.
 - Do not claim interactive gameplay validation without Xcode.
 
-## Verification
+## Work Completed
 
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- `python3 -m py_compile scripts/check-baseline.py`
-- Parse plist, storyboard, workspace, project, and workflow metadata with all
-  available local parsers.
-- `git diff --check`
-- Hostile mutations removing finite, positive, or ordered-range validation,
-  optional failure, guard-before-add ordering, plan status, or verification
-  evidence must be rejected.
+- Added an optional spawn-Y helper that rejects non-finite, non-positive, and
+  undersized scene geometry before constructing a closed random range.
+- Guarded the helper result before the monster enters the scene or receives
+  physics and movement behavior.
+- Added method-scoped static contracts and documented the boundary.
+
+## Verification Completed
+
+- All four Make gates, `make lint`, `make test`, `make build`, and `make check`,
+  passed against the complete static baseline.
+- `python3 -m py_compile scripts/check-baseline.py`, plist parsing, storyboard
+  and workspace XML parsing, workflow YAML parsing, and `git diff --check`
+  passed.
+- Eight hostile mutations removing either finite check, the positive-height
+  check, ordered-range validation, the optional helper contract,
+  guard-before-add ordering, completed plan status, or verification evidence
+  were rejected.
+- The local environment did not provide `xcodebuild`, so interactive SpriteKit
+  gameplay, rendering, audio, and physics execution were not claimed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,7 @@ CI_PLAN = ROOT / "docs/plans/2026-06-10-ci-baseline.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
+UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -146,6 +147,7 @@ def main():
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-swift-5-spritekit-build.md",
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
+        "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/readme-overview.svg",
     ]
 
@@ -197,6 +199,7 @@ def main():
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     swift_5_build_plan = SWIFT_5_BUILD_PLAN.read_text(encoding="utf-8") if SWIFT_5_BUILD_PLAN.exists() else ""
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
+    undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -235,11 +238,32 @@ def main():
     add_monster_index = game_scene.find("func addMonster()")
     spawn_guard_index = game_scene.find("if gameIsOver { return }", add_monster_index)
     create_enemy_index = game_scene.find("let monster = SKSpriteNode", add_monster_index)
+    spawn_y_index = game_scene.find("func monsterSpawnY(spriteHeight: CGFloat) -> CGFloat?")
+    next_helper_index = game_scene.find("func roundSquareImage", spawn_y_index)
+    spawn_y_body = game_scene[spawn_y_index:next_helper_index]
+    spawn_y_guard_index = game_scene.find(
+        "guard let actualY = monsterSpawnY(spriteHeight: monster.size.height) else",
+        add_monster_index,
+    )
+    add_child_index = game_scene.find("addChild(monster)", add_monster_index)
     require('withKey: "monsterSpawn"' in game_scene and 'removeAction(forKey: "monsterSpawn")' in game_scene,
             "GameScene must run enemy spawning with a key and remove it when game-over presentation starts",
             failures)
     require(add_monster_index != -1 and spawn_guard_index != -1 and spawn_guard_index < create_enemy_index,
             "GameScene must guard enemy spawning after game over before creating sprites",
+            failures)
+    require(spawn_y_index != -1 and next_helper_index != -1 and
+            "guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else" in spawn_y_body and
+            "let minY = spriteHeight / 2" in spawn_y_body and
+            "let maxY = size.height - minY" in spawn_y_body and
+            "guard minY <= maxY else" in spawn_y_body and
+            "return random(min: minY, max: maxY)" in spawn_y_body,
+            "monsterSpawnY must reject invalid geometry before constructing the closed random range",
+            failures)
+    require(spawn_y_guard_index != -1 and add_child_index != -1 and
+            create_enemy_index < spawn_y_guard_index < add_child_index and
+            "random(min: monster.size.height/2" not in game_scene,
+            "addMonster must skip invalid spawn geometry before adding the monster",
             failures)
     require("guard let originalPicture = UIImage(named: imageName)" in game_scene and
             "guard let scaledImage = UIGraphicsGetImageFromCurrentImageContext()" in game_scene and
@@ -346,7 +370,8 @@ def main():
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and
             "background scroll" in readme.lower() and "per-frame" in readme.lower() and "collision handler" in readme.lower() and
-            "contact delegate" in readme.lower() and "restart" in readme.lower() and "GitHub Actions" in readme,
+            "contact delegate" in readme.lower() and "restart" in readme.lower() and
+            "undersized scene" in readme.lower() and "GitHub Actions" in readme,
             "README must document static verification, project usage, SpriteKit context, collision handler guardrails, and image guardrails",
             failures)
     require("local game" in readme.lower() and "debug logging" in readme.lower() and "debug overlays" in readme.lower(),
@@ -355,19 +380,23 @@ def main():
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "asset" in vision.lower() and
             "game-over" in vision.lower() and "spawn" in vision.lower() and
             "background scroll" in vision.lower() and "per-frame" in vision.lower() and "collision handler" in vision.lower() and
-            "contact delegate" in vision.lower() and "restart" in vision.lower() and "GitHub Actions" in vision,
+            "contact delegate" in vision.lower() and "restart" in vision.lower() and
+            "undersized scene" in vision.lower() and "GitHub Actions" in vision,
             "VISION must describe the current static SpriteKit baseline",
             failures)
     require("debug logging" in security.lower() and "debug overlays" in security.lower() and
             "spawn" in security.lower() and "background scroll" in security.lower() and "per-frame" in security.lower() and
             "collision handler" in security.lower() and "contact delegate" in security.lower() and
-            "restart" in security.lower() and "make check" in security and "GitHub Actions" in security,
+            "restart" in security.lower() and "undersized scene" in security.lower() and
+            "make check" in security and "GitHub Actions" in security,
             "SECURITY must document debug logging/overlay and static baseline guardrails",
             failures)
     require("debug console logging" in changes and "debug overlays" in changes and "player-hit" in changes and
             "projectile" in changes and "zero-length" in changes and "image" in changes.lower() and
             "game-over" in changes.lower() and "restart" in changes.lower() and "spawn" in changes.lower() and
-            "background scroll" in changes.lower() and "per-frame" in changes.lower() and "make check" in changes and "make lint" in changes and "make test" in changes and "make build" in changes,
+            "background scroll" in changes.lower() and "per-frame" in changes.lower() and
+            "undersized scene" in changes.lower() and "make check" in changes and
+            "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record the debug cleanup, contact handling, vector guard, image guard, game-over guard, spawn guard, and baseline",
             failures)
     require("collision handler" in changes.lower(),
@@ -410,6 +439,11 @@ def main():
             failures)
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
+            failures)
+    require("status: completed" in undersized_spawn_plan and
+            "All four Make gates" in undersized_spawn_plan and
+            "hostile mutations" in undersized_spawn_plan.lower(),
+            "undersized scene spawn plan must record completed status and verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan


### PR DESCRIPTION
## Summary

Skip enemy spawning when the current SpriteKit scene cannot contain the monster sprite, preventing an invalid closed random range from trapping.

## Baseline

This PR is stacked on `lfg/ios-emoji-thrower-evidence-20260612` / PR #5 so it contains only the undersized-scene spawn guard and its verification evidence.

## Improvements

- validate finite, positive sprite and scene heights before random placement
- reject scenes shorter than the sprite before constructing `min...max`
- guard placement before adding physics, movement, sound, or the sprite node
- enforce the behavior with method-scoped static contracts and documentation

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- plist, storyboard, workspace XML, and workflow YAML parsing
- `git diff --check`
- eight hostile mutations rejected

The local environment did not provide `xcodebuild`; interactive SpriteKit gameplay, rendering, audio, and physics execution were not claimed.

## Risk

Normal valid scene geometry preserves the existing uniform closed-range placement, cadence, speed, physics, scoring, contact handling, and game-over behavior. Invalid geometry now skips one scheduled spawn.

## Follow-Ups

Hosted macOS CI should compile the exact head through the canonical `make check` workflow. The historical secret-scanning alert is outside this change and still requires owner-side credential rotation/closure.