### PR TITLE
fix: reject non-finite projectile vectors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected non-finite touch vectors before projectile physics, insertion,
+  movement, or sound effects.
 - Skipped enemy spawning for invalid or undersized scene geometry before
   constructing a closed random range or adding the SpriteKit node.
 

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -115,6 +115,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
 
         return random(min: minY, max: maxY)
     }
+
+    func projectileDirection(offset: CGPoint) -> CGPoint? {
+        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
+            return nil
+        }
+
+        let offsetLength = offset.length()
+        guard offsetLength.isFinite, offsetLength > 0 else {
+            return nil
+        }
+
+        let direction = offset / offsetLength
+        guard direction.x.isFinite, direction.y.isFinite else {
+            return nil
+        }
+
+        return direction
+    }
     
     //MARK: - Get Profile Picture
     func roundSquareImage(imageName: String) -> SKSpriteNode {
@@ -237,8 +255,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Determine offset of touch location to projectile
         let offset = touchLocation - projectile.position
         
-        // Cancel shots that do not travel forward.
-        if (offset.x <= 0) { return }
+        guard let direction = projectileDirection(offset: offset) else {
+            return
+        }
         
         // Projectile collision set up
         projectile.physicsBody = SKPhysicsBody(circleOfRadius: projectile.size.width/2)
@@ -250,9 +269,6 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         // Add projectile after double-checking direction of shot
         addChild(projectile)
-        
-        // Get the direction of where to shoot
-        let direction = offset.normalized()
         
         // Make it shoot far enough to be guaranteed off screen
         let shootDistance = direction * 1000

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
-- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Stop enemy spawning as soon as game-over presentation starts
 - Skip enemy spawning when invalid or undersized scene geometry cannot contain
   the monster sprite
+- Reject non-finite touch vectors before projectile side effects
 - Keep background scroll movement running per-frame until game over
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode

--- a/docs/plans/2026-06-13-finite-projectile-touch-vector.md
+++ b/docs/plans/2026-06-13-finite-projectile-touch-vector.md
@@ -1,6 +1,6 @@
 # Finite Projectile Touch Vector Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,3 +40,30 @@ before the projectile is removed.
 - Hostile mutations must reject missing component or length finiteness checks,
   acceptance of non-forward vectors, direction validation after node insertion,
   stale plan status, and missing verification evidence.
+
+## Work Completed
+
+- Added a pure optional direction helper that rejects non-finite components,
+  non-forward offsets, and zero, non-finite, or overflowed lengths.
+- Required the normalized direction itself to remain finite before returning it.
+- Moved direction validation before projectile physics, node insertion,
+  movement, and sound effects.
+- Documented the finite touch-vector boundary without changing gameplay tuning,
+  resources, project files, or workflow policy.
+
+## Verification Completed
+
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, plist, XML, and workflow YAML parsing,
+  and `git diff --check` passed.
+- Seven isolated hostile mutations were rejected: removed horizontal component
+  finiteness, removed vertical component finiteness, removed length finiteness,
+  accepted non-forward vectors, validated after node insertion, stale plan
+  status, and missing verification evidence.
+- Exact-base comparison confirmed project files, bundled resources, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact, secret-pattern, and forbidden data-flow
+  scans passed.
+- Hosted macOS simulator compilation and code-scanning evidence is recorded
+  separately after push; this plan claims only completed local static evidence.

--- a/docs/plans/2026-06-13-finite-projectile-touch-vector.md
+++ b/docs/plans/2026-06-13-finite-projectile-touch-vector.md
@@ -1,0 +1,42 @@
+# Finite Projectile Touch Vector Guard
+
+status: planned
+
+## Context
+
+Projectile launching rejects non-forward touches, but a NaN horizontal offset
+makes the `<= 0` comparison false. Non-finite or overflow-length touch vectors
+can then propagate through normalization into SpriteKit positions and actions
+before the projectile is removed.
+
+## Requirements
+
+- R1. Reject non-finite horizontal and vertical touch offsets.
+- R2. Reject non-forward offsets and zero, non-finite, or overflowed vector
+  lengths before normalization.
+- R3. Return a finite normalized direction only for valid forward vectors.
+- R4. Validate direction before projectile physics, node insertion, movement,
+  or sound effects.
+- R5. Preserve ordinary forward-shot behavior, game-over guards, collision
+  handling, and local-only gameplay.
+
+## Scope Boundaries
+
+- Do not change projectile speed, distance, image, physics categories, sound, or
+  collision scoring.
+- Do not add network, persistence, analytics, authentication, or remote assets.
+- Do not modify project files, bundled resources, or hosted workflow policy.
+- Local Linux validation must remain truthful about unavailable `xcodebuild`.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- plist, XML, and workflow YAML parsing
+- `git diff --check`
+- Hostile mutations must reject missing component or length finiteness checks,
+  acceptance of non-forward vectors, direction validation after node insertion,
+  stale plan status, and missing verification evidence.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation
 SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
+FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -148,6 +149,7 @@ def main():
         "docs/plans/2026-06-10-swift-5-spritekit-build.md",
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
+        "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/readme-overview.svg",
     ]
 
@@ -200,6 +202,7 @@ def main():
     swift_5_build_plan = SWIFT_5_BUILD_PLAN.read_text(encoding="utf-8") if SWIFT_5_BUILD_PLAN.exists() else ""
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
+    finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -286,8 +289,43 @@ def main():
     require("let pointLength = length()" in game_scene and "return CGPoint.zero" in game_scene,
             "CGPoint normalization must handle zero-length vectors",
             failures)
-    require("if (offset.x <= 0) { return }" in game_scene and "let direction = offset.normalized()" in game_scene,
-            "GameScene must guard non-forward projectile vectors before normalization",
+    projectile_direction_index = game_scene.find(
+        "func projectileDirection(offset: CGPoint) -> CGPoint?"
+    )
+    projectile_direction_end = game_scene.find(
+        "func roundSquareImage", projectile_direction_index
+    )
+    projectile_direction_body = game_scene[
+        projectile_direction_index:projectile_direction_end
+    ]
+    touches_ended_index = game_scene.find("override func touchesEnded")
+    touch_direction_guard_index = game_scene.find(
+        "guard let direction = projectileDirection(offset: offset) else",
+        touches_ended_index,
+    )
+    projectile_physics_index = game_scene.find(
+        "projectile.physicsBody =", touches_ended_index
+    )
+    projectile_add_index = game_scene.find("addChild(projectile)", touches_ended_index)
+    projectile_sound_index = game_scene.find(
+        "SKAction.playSoundFileNamed", touches_ended_index
+    )
+    require(projectile_direction_index != -1 and
+            "offset.x.isFinite" in projectile_direction_body and
+            "offset.y.isFinite" in projectile_direction_body and
+            "offset.x > 0" in projectile_direction_body and
+            "offsetLength.isFinite" in projectile_direction_body and
+            "offsetLength > 0" in projectile_direction_body and
+            "direction.x.isFinite" in projectile_direction_body and
+            "direction.y.isFinite" in projectile_direction_body,
+            "GameScene must reject non-finite, non-forward, and overflowed projectile vectors",
+            failures)
+    require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
+            projectile_physics_index != -1 and projectile_add_index != -1 and
+            projectile_sound_index != -1 and
+            touch_direction_guard_index < projectile_physics_index <
+            projectile_add_index < projectile_sound_index,
+            "GameScene must validate projectile direction before physics, insertion, and sound",
             failures)
     require("projectileDidCollideWithMonster(projectile, monster: monster)" in game_scene and
             "monsterDidCollideWithPlayer(monster, player: player)" in game_scene and
@@ -399,6 +437,12 @@ def main():
             "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record the debug cleanup, contact handling, vector guard, image guard, game-over guard, spawn guard, and baseline",
             failures)
+    require("non-finite touch vectors" in readme.lower() and
+            "non-finite touch vectors" in security.lower() and
+            "non-finite touch vectors" in vision.lower() and
+            "non-finite touch vectors" in changes.lower(),
+            "Docs must record finite projectile touch-vector validation",
+            failures)
     require("collision handler" in changes.lower(),
             "CHANGES must record the collision handler game-over guard",
             failures)
@@ -444,6 +488,31 @@ def main():
             "All four Make gates" in undersized_spawn_plan and
             "hostile mutations" in undersized_spawn_plan.lower(),
             "undersized scene spawn plan must record completed status and verification",
+            failures)
+    finite_touch_statuses = re.findall(
+        r"^status: .+$", finite_touch_vector_plan, flags=re.MULTILINE
+    )
+    finite_touch_sections = finite_touch_vector_plan.split(
+        "## Verification Completed\n", 1
+    )
+    finite_touch_verification = (
+        finite_touch_sections[1] if len(finite_touch_sections) == 2 else ""
+    )
+    finite_touch_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "plist, XML, and workflow YAML parsing",
+        "git diff --check",
+        "Seven isolated hostile mutations",
+    )
+    require(finite_touch_statuses == ["status: completed"]
+            and all(item in finite_touch_verification
+                    for item in finite_touch_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          finite_touch_verification,
+                          re.IGNORECASE) is None,
+            "finite projectile touch-vector plan must record completed status and actual local verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan


### PR DESCRIPTION
## Summary

- harden projectile creation against invalid touch-derived vectors
- add mutation-sensitive static contracts, documentation, and completed local plan evidence

## Baseline

- this PR is stacked on #6 and targets its `lfg/ios-emoji-thrower-touch-vector-20260613` branch
- projectile input previously lacked complete rejection of non-finite and otherwise unusable vectors

## Improvements

- reject non-finite, non-forward, zero-length, and overflow-length projectile touch vectors
- validate the normalized direction before physics, node insertion, movement, or sound

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- plist, XML, JSON, and workflow YAML parsing
- `git diff --check`
- seven isolated hostile mutations
- intended-path secret-pattern, generated-artifact, and forbidden data-flow scans

## Risk

- local Linux validation truthfully reported `xcodebuild` unavailable
- historical secret-scanning alert #1 is unrelated to this exact-head diff

## Follow-Ups

- review this stacked PR after #6
- rotate and close historical secret-scanning alert #1 on the owner side
