### PR TITLE
fix: make emoji checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made all Make verification aliases location-independent when invoked through
+  an absolute Makefile path.
 - Rejected non-finite touch vectors before projectile physics, insertion,
   movement, or sound effects.
 - Skipped enemy spawning for invalid or undersized scene geometry before

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
+	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-10-swift-5-spritekit-build.md` for the Swift 5
   simulator-build migration.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, plist/storyboard files, SpriteKit assets, sounds, fonts, Xcode metadata, or gameplay/privacy documentation.
+- The same gates may be invoked through an absolute Makefile path from another
+  directory; verification resolves the checker relative to the checkout.
 
 ## Contributing
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,13 +1,13 @@
 # Location-Independent Emoji Thrower Verification
 
-status: in progress
+status: completed
 
 ## Context
 
-Absolute Makefile invocations currently resolve `scripts/check-baseline.py`
-relative to the caller instead of the checkout. This makes the documented
+Absolute Makefile invocations previously resolved `scripts/check-baseline.py`
+relative to the caller instead of the checkout. That made the documented
 verification aliases fail outside the repository directory even though the
-checker itself already derives the checkout root from its own path.
+checker itself already derived the checkout root from its own path.
 
 ## Scope
 
@@ -26,6 +26,24 @@ checker itself already derives the checkout root from its own path.
   documentation mutations independently.
 - Inspect intended paths, secret patterns, conflict markers, and generated
   artifacts before commit.
+
+## Work Completed
+
+- Derived the checkout root from the loaded Makefile and invoked the baseline
+  checker by absolute path.
+- Added exact Makefile, completed-plan, external-run, and synchronized guidance
+  contracts without changing gameplay, project, resource, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- All four Make gates passed from `/tmp` through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Local validation reported that `xcodebuild` was unavailable and therefore ran
+  the static iOS baseline only.
+- Five isolated hostile mutations were rejected: root derivation, checker
+  invocation, plan status, plan evidence, and documentation guidance.
 
 ## Risk And Rollback
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,33 @@
+# Location-Independent Emoji Thrower Verification
+
+status: in progress
+
+## Context
+
+Absolute Makefile invocations currently resolve `scripts/check-baseline.py`
+relative to the caller instead of the checkout. This makes the documented
+verification aliases fail outside the repository directory even though the
+checker itself already derives the checkout root from its own path.
+
+## Scope
+
+1. Derive the checkout root from the loaded Makefile.
+2. Invoke the baseline checker from that root for every Make alias.
+3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
+4. Preserve SpriteKit behavior, project metadata, resources, and workflow
+   policy.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through an absolute Makefile
+  path from a temporary directory.
+- Run checker compilation, project metadata parsing, and diff checks.
+- Reject root-derivation, checker-invocation, plan-status, plan-evidence, and
+  documentation mutations independently.
+- Inspect intended paths, secret patterns, conflict markers, and generated
+  artifacts before commit.
+
+## Risk And Rollback
+
+This changes verification path resolution only. Rollback restores the relative
+Make recipe and removes its checker, plan, and documentation contracts.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -150,6 +151,7 @@ def main():
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
         "docs/readme-overview.svg",
     ]
 
@@ -203,6 +205,7 @@ def main():
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -402,8 +405,12 @@ def main():
     require("*.local.xcconfig" in gitignore and ".env" in gitignore and "DerivedData" in gitignore,
             ".gitignore must exclude local config and Xcode build products",
             failures)
-    require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
-            "Makefile must expose lint, test, and build aliases for the local baseline",
+    require(".PHONY: build check lint test" in makefile and
+            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "lint test build: check" in makefile and
+            'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
+            "python3 scripts/check-baseline.py" not in makefile,
+            "Makefile must expose location-independent lint, test, build, and check aliases",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and
@@ -442,6 +449,10 @@ def main():
             "non-finite touch vectors" in vision.lower() and
             "non-finite touch vectors" in changes.lower(),
             "Docs must record finite projectile touch-vector validation",
+            failures)
+    require("absolute makefile path" in readme.lower() and
+            "location-independent" in changes.lower(),
+            "README and CHANGES must document location-independent Make verification",
             failures)
     require("collision handler" in changes.lower(),
             "CHANGES must record the collision handler game-over guard",
@@ -488,6 +499,24 @@ def main():
             "All four Make gates" in undersized_spawn_plan and
             "hostile mutations" in undersized_spawn_plan.lower(),
             "undersized scene spawn plan must record completed status and verification",
+            failures)
+    location_make_statuses = re.findall(
+        r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE
+    )
+    location_make_verification = markdown_section(
+        location_independent_make_plan, "Verification Completed"
+    )
+    require(location_make_statuses == ["status: completed"] and
+            "All four Make gates passed from the checkout" in location_make_verification and
+            "All four Make gates passed from `/tmp` through the absolute Makefile path" in location_make_verification and
+            "python3 -m py_compile scripts/check-baseline.py" in location_make_verification and
+            "git diff --check" in location_make_verification and
+            "`xcodebuild` was unavailable" in location_make_verification and
+            "Five isolated hostile mutations were rejected" in location_make_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      location_make_verification,
+                      re.IGNORECASE) is None,
+            "location-independent Make plan must record completed status and actual local verification",
             failures)
     finite_touch_statuses = re.findall(
         r"^status: .+$", finite_touch_vector_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

The documented Make gates now work when called through an absolute Makefile path from outside the checkout. Verification derives the repository root from the loaded Makefile, while static contracts prevent the path fix or its completed evidence from regressing.

## Baseline

- The documented Make gates previously depended on the caller's working directory.
- Full Xcode build execution is unavailable in the local Linux environment.
- Application behavior, project sources, dependencies, and workflows remain outside this verification-focused change.

## Improvements

- Derive the repository root from the loaded Makefile.
- Make the documented quality gates location-independent.
- Add static contracts that protect the path fix and its completed plan evidence from regression.

## Validation

- All four Make gates passed from the checkout and from `/tmp`
- Project plist, XML, JSON, and workflow YAML parsing passed
- Checker compilation and `git diff --check` passed
- Five isolated hostile mutations were rejected
- Intended-path, secret-pattern, conflict-marker, and generated-artifact audits passed
- Local Linux validation truthfully skipped `xcodebuild`

## Risk

- Full Xcode compilation and runtime behavior were not validated locally because the available environment is Linux.
- This PR is stacked on PR #7 (`lfg/ios-emoji-thrower-finite-touch-vector-20260613`) and must not be merged independently.

## Follow-Ups

- Preserve and merge PR #7 first, or rebase this work before independent delivery.
- Run the Xcode build and relevant simulator/device checks in a supported macOS environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
