### PR TITLE
fix: ignore stale player contacts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Ignored queued player contacts after either collision node has already left
+  the active scene.
+
 ## 2026-06-13
 
 - Made all Make verification aliases location-independent when invoked through

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -314,6 +314,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     }
     func monsterDidCollideWithPlayer(_ monster:SKSpriteNode, player:SKSpriteNode) {
         if gameIsOver { return }
+        guard monster.parent === self, player.parent === self else { return }
 
         playerDestroyed = true
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, stale collision nodes, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -122,6 +122,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-10-game-over-restart-guard.md` for the game-over restart guardrail.
 - See `docs/plans/2026-06-13-undersized-scene-spawn-guard.md` for the enemy
   spawn geometry guardrail.
+- See `docs/plans/2026-06-14-stale-player-contact-guard.md` for the stale player
+  collision guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/docs/plans/2026-06-14-stale-player-contact-guard.md
+++ b/docs/plans/2026-06-14-stale-player-contact-guard.md
@@ -1,0 +1,42 @@
+# Stale Player Contact Guard
+
+status: planned
+
+## Context
+
+SpriteKit can deliver multiple contacts involving the same monster during one
+physics step. A projectile contact removes the monster, but a queued player
+contact can still reach `monsterDidCollideWithPlayer` and end the game even
+though that monster is no longer active in the scene.
+
+## Requirements
+
+- Require both the monster and player to remain attached to the active scene
+  before mutating player state or presenting game over.
+- Preserve the existing game-over guard, loss transition, projectile scoring,
+  and 20-hit win threshold.
+- Extend the static baseline with an ordering contract that rejects a missing
+  or late active-node guard.
+- Keep project files, bundled assets, gameplay tuning, and workflow policy
+  unchanged.
+
+## Implementation
+
+- Add an active-node guard at the start of the player collision handler after
+  the existing game-over check.
+- Update `scripts/check-baseline.py` to require the guard before player state
+  mutation and node removal.
+- Synchronize verification documentation after all local gates and hostile
+  mutations complete.
+
+## Verification
+
+- Run the focused static baseline and all Make gates from the repository.
+- Run the full gate through an absolute Makefile path from an external working
+  directory.
+- Compile the Python checker and validate shell, project, plist, XML, and
+  workflow syntax where supported.
+- Prove hostile mutations are rejected for the active-node predicate, guard
+  ordering, checker discovery, plan status, and verification evidence.
+- Audit the exact diff, generated artifacts, and intended files for secret
+  patterns before committing.

--- a/docs/plans/2026-06-14-stale-player-contact-guard.md
+++ b/docs/plans/2026-06-14-stale-player-contact-guard.md
@@ -1,6 +1,6 @@
 # Stale Player Contact Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,3 +40,24 @@ though that monster is no longer active in the scene.
   ordering, checker discovery, plan status, and verification evidence.
 - Audit the exact diff, generated artifacts, and intended files for secret
   patterns before committing.
+
+## Work Completed
+
+- Required both collision nodes to remain attached to the active scene before
+  the player collision handler mutates state or presents the loss scene.
+- Extended the static baseline with guard-presence and ordering assertions.
+- Updated the README and changelog to describe the stale-contact boundary.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout and reported that `xcodebuild` was unavailable,
+  so this Linux host exercised the complete static baseline.
+- The full gate passed from an external directory through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py`, shell syntax, plist, XML,
+  project, and workflow parsing, and `git diff --check` passed.
+- Five isolated hostile mutations were rejected: missing active-node guard,
+  late guard ordering, missing plan discovery, stale plan status, and missing
+  verification evidence.
+- Exact intended-file generated-artifact and secret-pattern audits passed.
+- Hosted macOS simulator compilation and code-scanning evidence is recorded
+  separately after push; this plan claims only completed local evidence.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -27,6 +27,7 @@ DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-cont
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -152,6 +153,7 @@ def main():
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-14-stale-player-contact-guard.md",
         "docs/readme-overview.svg",
     ]
 
@@ -206,6 +208,7 @@ def main():
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -370,10 +373,17 @@ def main():
             failures)
     player_collision_index = game_scene.find("func monsterDidCollideWithPlayer")
     player_guard_index = game_scene.find("if gameIsOver { return }", player_collision_index)
+    player_active_node_guard_index = game_scene.find("guard monster.parent === self, player.parent === self else { return }", player_collision_index)
     player_destroyed_index = game_scene.find("playerDestroyed = true", player_collision_index)
+    player_remove_index = game_scene.find("player.removeFromParent()", player_collision_index)
     require(player_collision_index != -1 and player_guard_index != -1 and
             player_destroyed_index != -1 and player_guard_index < player_destroyed_index,
             "Player collision handler must ignore late contacts before mutating player state",
+            failures)
+    require(player_active_node_guard_index != -1 and
+            player_guard_index < player_active_node_guard_index < player_destroyed_index and
+            player_active_node_guard_index < player_remove_index,
+            "Player collisions must require active nodes before mutating player state",
             failures)
     game_view_controller = read("EmojiThrower/GameViewController.swift")
     require("guard let skView = view as? SKView" in game_view_controller,
@@ -542,6 +552,23 @@ def main():
                           finite_touch_verification,
                           re.IGNORECASE) is None,
             "finite projectile touch-vector plan must record completed status and actual local verification",
+            failures)
+    stale_player_contact_statuses = re.findall(
+        r"^status: .+$", stale_player_contact_plan, flags=re.MULTILINE
+    )
+    stale_player_contact_verification = markdown_section(
+        stale_player_contact_plan, "Verification Completed"
+    )
+    require(stale_player_contact_statuses == ["status: completed"] and
+            "All four Make gates" in stale_player_contact_verification and
+            "absolute Makefile path" in stale_player_contact_verification and
+            "Five isolated hostile mutations" in stale_player_contact_verification and
+            "git diff --check" in stale_player_contact_verification and
+            "`xcodebuild` was unavailable" in stale_player_contact_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      stale_player_contact_verification,
+                      re.IGNORECASE) is None,
+            "stale player contact plan must record completed status and actual local verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan


### PR DESCRIPTION
## Summary

A monster removed by a projectile can no longer end the game through a queued player contact from the same SpriteKit physics step. Player-loss handling now requires both collision nodes to remain attached to the active scene before changing state.

## Baseline

This PR is stacked on `lfg/ios-emoji-thrower-location-independent-make-20260613` (PR #8) so it contains only the stale-contact guard and its verification contract.

## Improvements

- Reject stale player contacts before mutating `playerDestroyed`, removing the player, or presenting the loss scene.
- Extend the static baseline with guard-presence and ordering assertions.
- Document the collision lifecycle boundary and completed local evidence.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- Absolute Makefile invocation from `/tmp`
- Python checker compilation, shell syntax, plist/XML/project/workflow parsing, and `git diff --check`
- Five isolated hostile mutations, all rejected
- Intended-file artifact and secret-pattern audits

Local validation reports that `xcodebuild` is unavailable, so simulator compilation remains delegated to the pinned hosted macOS check.

## Risk

The behavior change is limited to ignoring contacts whose nodes have already left the active scene. Projectile scoring, active player collisions, transitions, assets, project settings, and workflow policy are unchanged.

## Follow-Ups

- Preserve stack order: merge PR #8 before this PR.
- Historical secret-scanning alert #1 still requires repository-owner credential revocation or rotation verification and is not changed by this PR.

## Post-Deploy Monitoring & Validation

- Require both canonical push and pull-request checks to pass on the exact head.
- Confirm branch and PR-head code-scanning alerts remain zero.
- Exercise overlapping projectile/player contacts on a simulator or physical device when Apple tooling is available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
