### PR TITLE
test: execute projectile math behavior in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,14 @@ player launches emoji projectiles at moving targets.
 
 ## Coding conventions
 
-- Language mix noted in the README: Swift (9).
+- Language mix noted in the README: Swift (10).
 - Preserve the checked-in Swift 5, iOS 12, Xcode, and signing assumptions unless
   the change is explicitly about modernization.
 
 ## Testing guidance
 
-- No dedicated test files were detected; treat `make check` as the minimum baseline.
+- `make check` compiles and runs the shared projectile-math harness when
+  `swiftc` is available; hosted macOS is the authoritative execution boundary.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Added executable Swift tests for projectile direction normalization using the
+  same finite-vector implementation as the SpriteKit scene.
+
 ## 2026-06-14
 
 - Ignored queued player contacts after either collision node has already left

--- a/EmojiThrower.xcodeproj/project.pbxproj
+++ b/EmojiThrower.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7FB5DE681D14C62600813314 /* GameOverScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE641D14C62600813314 /* GameOverScene.swift */; };
 		7FB5DE691D14C62600813314 /* GameScene.sks in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE651D14C62600813314 /* GameScene.sks */; };
 		7FB5DE6A1D14C62600813314 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE661D14C62600813314 /* GameScene.swift */; };
+		A16061611D14C62600813314 /* ProjectileMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621D14C62600813314 /* ProjectileMath.swift */; };
 		7FB5DE6B1D14C62600813314 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE671D14C62600813314 /* GameViewController.swift */; };
 		7FB5DE701D14C63000813314 /* background-music-aac.caf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE6D1D14C63000813314 /* background-music-aac.caf */; };
 		7FB5DE711D14C63000813314 /* pew-pew-lei.caf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE6E1D14C63000813314 /* pew-pew-lei.caf */; };
@@ -34,6 +35,7 @@
 		7FB5DE641D14C62600813314 /* GameOverScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameOverScene.swift; sourceTree = "<group>"; };
 		7FB5DE651D14C62600813314 /* GameScene.sks */ = {isa = PBXFileReference; lastKnownFileType = file.sks; path = GameScene.sks; sourceTree = "<group>"; };
 		7FB5DE661D14C62600813314 /* GameScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameScene.swift; sourceTree = "<group>"; };
+		A16061621D14C62600813314 /* ProjectileMath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectileMath.swift; sourceTree = "<group>"; };
 		7FB5DE671D14C62600813314 /* GameViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameViewController.swift; sourceTree = "<group>"; };
 		7FB5DE6D1D14C63000813314 /* background-music-aac.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "background-music-aac.caf"; sourceTree = "<group>"; };
 		7FB5DE6E1D14C63000813314 /* pew-pew-lei.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "pew-pew-lei.caf"; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				7FB5DE641D14C62600813314 /* GameOverScene.swift */,
 				7FB5DE651D14C62600813314 /* GameScene.sks */,
 				7FB5DE661D14C62600813314 /* GameScene.swift */,
+				A16061621D14C62600813314 /* ProjectileMath.swift */,
 				7FB5DE6C1D14C63000813314 /* Sounds */,
 				7FB5DE6F1D14C63000813314 /* sprites.atlas */,
 				7FB5DE601D14C5F100813314 /* Assets.xcassets */,
@@ -203,6 +206,7 @@
 				7FB5DE6B1D14C62600813314 /* GameViewController.swift in Sources */,
 				7FB5DE681D14C62600813314 /* GameOverScene.swift in Sources */,
 				7FB5DE6A1D14C62600813314 /* GameScene.swift in Sources */,
+				A16061611D14C62600813314 /* ProjectileMath.swift in Sources */,
 				7FB5DE4F1D14C5BC00813314 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -117,21 +117,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     func projectileDirection(offset: CGPoint) -> CGPoint? {
-        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
-            return nil
-        }
-
-        let offsetLength = offset.length()
-        guard offsetLength.isFinite, offsetLength > 0 else {
-            return nil
-        }
-
-        let direction = offset / offsetLength
-        guard direction.x.isFinite, direction.y.isFinite else {
-            return nil
-        }
-
-        return direction
+        return ProjectileMath.direction(offset: offset)
     }
     
     //MARK: - Get Profile Picture

--- a/EmojiThrower/ProjectileMath.swift
+++ b/EmojiThrower/ProjectileMath.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum ProjectileMath {
+    static func direction(offset: CGPoint) -> CGPoint? {
+        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
+            return nil
+        }
+
+        let offsetLength = sqrt(offset.x * offset.x + offset.y * offset.y)
+        guard offsetLength.isFinite, offsetLength > 0 else {
+            return nil
+        }
+
+        let direction = CGPoint(x: offset.x / offsetLength, y: offset.y / offsetLength)
+        guard direction.x.isFinite, direction.y.isFinite else {
+            return nil
+        }
+
+        return direction
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 .PHONY: build check lint test
 
+SWIFTC ?= swiftc
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 
 check:
+	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-projectile-math-tests.sh"; \
+	else \
+		echo "swiftc unavailable; executable projectile math tests skipped"; \
+	fi
 	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `garethpaul/ios-emoji-thrower` is a Swift 5 SpriteKit game sample in which the
 player launches emoji projectiles at moving targets.
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (9).
+This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (10).
 
 ## Repository Contents
 
@@ -82,7 +82,15 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, stale collision nodes, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs executable Swift projectile-math tests when `swiftc` is
+available, then runs `scripts/check-baseline.py`. It parses
+plist/storyboard/asset metadata, validates the binary SpriteKit scene plist,
+checks Xcode resource references, verifies the Swift source inventory, and
+guards against image-helper force unwraps, non-finite touch vectors, repeated
+game-over transitions, unguarded game-over restarts, stale collision nodes,
+late collision handler mutations, uncleared contact delegate callbacks, late
+spawn actions, broken per-frame background scroll movement, debug logging,
+network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -124,6 +132,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   spawn geometry guardrail.
 - See `docs/plans/2026-06-14-stale-player-contact-guard.md` for the stale player
   collision guardrail.
+- See `docs/plans/2026-06-16-executable-projectile-math-tests.md` for the shared
+  projectile validation and executable Swift behavioral gate.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -40,7 +40,10 @@ expectPoint(
     y: -0.8,
     "negative vertical offsets preserve direction"
 )
-expectNil(ProjectileMath.direction(offset: .zero), "zero-length offsets are rejected")
+expectNil(
+    ProjectileMath.direction(offset: CGPoint(x: 0.0, y: 0.0)),
+    "zero-length offsets are rejected"
+)
 expectNil(ProjectileMath.direction(offset: CGPoint(x: -1.0, y: 0.0)), "backward offsets are rejected")
 expectNil(ProjectileMath.direction(offset: CGPoint(x: .nan, y: 1.0)), "NaN horizontal offsets are rejected")
 expectNil(ProjectileMath.direction(offset: CGPoint(x: 1.0, y: .nan)), "NaN vertical offsets are rejected")

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+private var failureCount = 0
+
+private func expectNil(_ value: CGPoint?, _ message: String) {
+    if value != nil {
+        failureCount += 1
+        fputs("FAIL: \(message): expected nil\n", stderr)
+    }
+}
+
+private func expectPoint(
+    _ actual: CGPoint?,
+    x expectedX: CGFloat,
+    y expectedY: CGFloat,
+    accuracy: CGFloat = 0.000_001,
+    _ message: String
+) {
+    guard let actual else {
+        failureCount += 1
+        fputs("FAIL: \(message): expected a direction\n", stderr)
+        return
+    }
+    if !actual.x.isFinite || !actual.y.isFinite ||
+        abs(actual.x - expectedX) > accuracy || abs(actual.y - expectedY) > accuracy {
+        failureCount += 1
+        fputs("FAIL: \(message): expected (\(expectedX), \(expectedY)), got (\(actual.x), \(actual.y))\n", stderr)
+    }
+}
+
+expectPoint(
+    ProjectileMath.direction(offset: CGPoint(x: 3.0, y: 4.0)),
+    x: 0.6,
+    y: 0.8,
+    "finite forward offsets normalize to unit direction"
+)
+expectPoint(
+    ProjectileMath.direction(offset: CGPoint(x: 3.0, y: -4.0)),
+    x: 0.6,
+    y: -0.8,
+    "negative vertical offsets preserve direction"
+)
+expectNil(ProjectileMath.direction(offset: .zero), "zero-length offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: -1.0, y: 0.0)), "backward offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: .nan, y: 1.0)), "NaN horizontal offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: 1.0, y: .nan)), "NaN vertical offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: .infinity, y: 1.0)), "infinite offsets are rejected")
+expectNil(
+    ProjectileMath.direction(offset: CGPoint(x: CGFloat.greatestFiniteMagnitude, y: CGFloat.greatestFiniteMagnitude)),
+    "overflowing vector lengths are rejected"
+)
+
+if failureCount > 0 {
+    exit(1)
+}
+
+print("ProjectileMath behavioral tests passed")

--- a/docs/plans/2026-06-16-executable-projectile-math-tests.md
+++ b/docs/plans/2026-06-16-executable-projectile-math-tests.md
@@ -1,0 +1,28 @@
+# Executable Projectile Math Tests
+
+Status: Completed
+
+## Goal
+
+Replace static-only confidence in projectile direction validation with
+executable Swift tests of the same implementation used by `GameScene`.
+
+## Implementation
+
+- Move finite, forward-only direction normalization into a Foundation-only
+  `ProjectileMath` helper.
+- Keep SpriteKit scene orchestration unchanged while delegating deterministic
+  vector validation to the shared helper.
+- Compile the helper and a repository-owned Swift harness through `make check`
+  whenever `swiftc` is available.
+- Keep the hosted macOS gate responsible for executable tests and the existing
+  unsigned iOS Simulator application build.
+
+## Verification
+
+- Repository and external-directory `make check` passed with explicit local
+  Swift/Xcode toolchain boundaries.
+- The harness covers finite normalization, downward shots, zero-length and
+  backward offsets, NaN and infinity, and overflowing vector lengths.
+- Hostile mutations were rejected for runner invocation, app delegation,
+  finite-vector guards, behavioral assertions, and Xcode source membership.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -28,6 +28,7 @@ UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-gua
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
+PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -118,6 +119,7 @@ def main():
         "EmojiThrower/Info.plist",
         "EmojiThrower/AppDelegate.swift",
         "EmojiThrower/GameScene.swift",
+        "EmojiThrower/ProjectileMath.swift",
         "EmojiThrower/GameViewController.swift",
         "EmojiThrower/GameOverScene.swift",
         "EmojiThrower/GameScene.sks",
@@ -154,7 +156,10 @@ def main():
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-stale-player-contact-guard.md",
+        "docs/plans/2026-06-16-executable-projectile-math-tests.md",
         "docs/readme-overview.svg",
+        "Tests/ProjectileMathTests/main.swift",
+        "scripts/run-projectile-math-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -182,6 +187,9 @@ def main():
     swift_sources = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
                               for path in sorted((ROOT / "EmojiThrower").glob("*.swift")))
     game_scene = read("EmojiThrower/GameScene.swift")
+    projectile_math = read("EmojiThrower/ProjectileMath.swift")
+    projectile_tests = read("Tests/ProjectileMathTests/main.swift")
+    projectile_test_runner = read("scripts/run-projectile-math-tests.sh")
     readme = read("README.md")
     vision = read("VISION.md")
     security = read("SECURITY.md")
@@ -209,6 +217,7 @@ def main():
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
+    projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -222,6 +231,10 @@ def main():
             failures)
     for resource in ["Assets.xcassets", "sprites.atlas", "background-music-aac.caf", "pew-pew-lei.caf", "Sketch3D.otf", "GameScene.sks"]:
         require(resource in project, f"Xcode project must keep resource reference: {resource}", failures)
+    require(project.count("ProjectileMath.swift in Sources") == 2 and
+            "path = ProjectileMath.swift;" in project,
+            "Xcode project must compile shared projectile math in the app target",
+            failures)
     require(app_plist.get("UIAppFonts") == ["Sketch3D.otf"],
             "Info.plist must register the bundled Sketch3D font",
             failures)
@@ -317,15 +330,38 @@ def main():
         "SKAction.playSoundFileNamed", touches_ended_index
     )
     require(projectile_direction_index != -1 and
-            "offset.x.isFinite" in projectile_direction_body and
-            "offset.y.isFinite" in projectile_direction_body and
-            "offset.x > 0" in projectile_direction_body and
-            "offsetLength.isFinite" in projectile_direction_body and
-            "offsetLength > 0" in projectile_direction_body and
-            "direction.x.isFinite" in projectile_direction_body and
-            "direction.y.isFinite" in projectile_direction_body,
-            "GameScene must reject non-finite, non-forward, and overflowed projectile vectors",
+            "return ProjectileMath.direction(offset: offset)" in projectile_direction_body,
+            "GameScene must delegate projectile validation to shared executable math",
             failures)
+    for fragment in [
+        "guard offset.x.isFinite, offset.y.isFinite, offset.x > 0",
+        "let offsetLength = sqrt(offset.x * offset.x + offset.y * offset.y)",
+        "guard offsetLength.isFinite, offsetLength > 0",
+        "let direction = CGPoint(x: offset.x / offsetLength, y: offset.y / offsetLength)",
+        "guard direction.x.isFinite, direction.y.isFinite",
+    ]:
+        require(fragment in projectile_math,
+                f"shared projectile math must preserve finite-vector contract: {fragment}",
+                failures)
+    for fragment in [
+        "if !actual.x.isFinite || !actual.y.isFinite",
+        "CGPoint(x: 3.0, y: 4.0)",
+        "CGPoint(x: -1.0, y: 0.0)",
+        "CGPoint(x: .nan, y: 1.0)",
+        "CGFloat.greatestFiniteMagnitude",
+    ]:
+        require(fragment in projectile_tests,
+                f"executable projectile behavior coverage is missing: {fragment}",
+                failures)
+    for fragment in [
+        '"$SWIFTC"',
+        '"$ROOT/EmojiThrower/ProjectileMath.swift"',
+        '"$ROOT/Tests/ProjectileMathTests/main.swift"',
+        '"$BUILD_DIR/projectile-math-tests"',
+    ]:
+        require(fragment in projectile_test_runner,
+                f"projectile behavior test runner is missing: {fragment}",
+                failures)
     require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
             projectile_physics_index != -1 and projectile_add_index != -1 and
             projectile_sound_index != -1 and
@@ -416,11 +452,22 @@ def main():
             ".gitignore must exclude local config and Xcode build products",
             failures)
     require(".PHONY: build check lint test" in makefile and
+            "SWIFTC ?= swiftc" in makefile and
             "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
             "lint test build: check" in makefile and
+            '"$(ROOT)/scripts/run-projectile-math-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
             "python3 scripts/check-baseline.py" not in makefile,
             "Makefile must expose location-independent lint, test, build, and check aliases",
+            failures)
+    require("Status: Completed" in projectile_test_plan and
+            "make check" in projectile_test_plan and
+            "hostile mutations" in projectile_test_plan.lower(),
+            "executable projectile math plan must preserve completed verification evidence",
+            failures)
+    require("docs/plans/2026-06-16-executable-projectile-math-tests.md" in readme and
+            "executable Swift" in readme,
+            "README must document executable projectile math coverage",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -346,6 +346,7 @@ def main():
     for fragment in [
         "if !actual.x.isFinite || !actual.y.isFinite",
         "CGPoint(x: 3.0, y: 4.0)",
+        "CGPoint(x: 0.0, y: 0.0)",
         "CGPoint(x: -1.0, y: 0.0)",
         "CGPoint(x: .nan, y: 1.0)",
         "CGFloat.greatestFiniteMagnitude",

--- a/scripts/run-projectile-math-tests.sh
+++ b/scripts/run-projectile-math-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/emoji-projectile-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/EmojiThrower/ProjectileMath.swift" \
+    "$ROOT/Tests/ProjectileMathTests/main.swift" \
+    -o "$BUILD_DIR/projectile-math-tests"
+
+"$BUILD_DIR/projectile-math-tests"


### PR DESCRIPTION
## Summary

Projectile direction validation is now executed as Swift behavior using the same finite-vector implementation that the SpriteKit scene calls. The canonical macOS gate runs those tests before the existing unsigned simulator build.

## Baseline

The repository previously protected non-finite, backward, zero-length, and overflowed touch vectors with static source assertions only. A syntactically matching implementation could still return incorrect directions without an executable test failing.

## Improvements

`GameScene` now delegates deterministic vector validation to a Foundation-only `ProjectileMath` helper. A repository-owned Swift harness covers normalized forward and downward shots plus zero-length, backward, NaN, infinite, and overflowing inputs.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- All four aliases through the absolute Makefile path from `/tmp`
- Python and shell syntax checks
- Xcode project source-membership and diff-integrity checks
- Eight hostile mutations rejected across runner invocation, canonical CI, production delegation, finite guards, behavioral assertions, project membership, and test inputs
- Local host recorded explicit `swiftc` and `xcodebuild` unavailability; hosted macOS execution is pending

## Risk

The public scene API and touch orchestration are unchanged, but vector math moved behind an internal helper. Hosted macOS compilation, executable Swift tests, and the simulator application build must pass at this exact head before the behavioral limitation can be cleared.

## Follow-Ups

Record exact-head hosted results once the canonical check reaches a terminal state. SpriteKit rendering, audio, physics simulation, and full gameplay remain outside this deterministic harness.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
