### PR TITLE
fix: make projectile travel scene aware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-17
+
+- Replaced the fixed projectile travel scalar with validated scene-aware
+  projectile travel that includes node clearance for wide and tall scenes.
+- Extended the executable Swift harness with scene geometry, projectile margin,
+  invalid dimension, and overflow cases.
+
 ## 2026-06-16
 
 - Added executable Swift tests for projectile direction normalization using the

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -244,6 +244,12 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         guard let direction = projectileDirection(offset: offset) else {
             return
         }
+        guard let projectileTravelDistance = ProjectileMath.exitDistance(
+            sceneSize: size,
+            projectileSize: projectile.size
+        ) else {
+            return
+        }
         
         // Projectile collision set up
         projectile.physicsBody = SKPhysicsBody(circleOfRadius: projectile.size.width/2)
@@ -256,8 +262,8 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Add projectile after double-checking direction of shot
         addChild(projectile)
         
-        // Make it shoot far enough to be guaranteed off screen
-        let shootDistance = direction * 1000
+        // Make it shoot far enough to move the whole node off screen.
+        let shootDistance = direction * projectileTravelDistance
         
         // Add the shoot amount to the current position
         let realDest = shootDistance + projectile.position

--- a/EmojiThrower/ProjectileMath.swift
+++ b/EmojiThrower/ProjectileMath.swift
@@ -18,4 +18,22 @@ enum ProjectileMath {
 
         return direction
     }
+
+    static func exitDistance(sceneSize: CGSize, projectileSize: CGSize) -> CGFloat? {
+        guard sceneSize.width.isFinite, sceneSize.height.isFinite,
+              sceneSize.width > 0, sceneSize.height > 0,
+              projectileSize.width.isFinite, projectileSize.height.isFinite,
+              projectileSize.width >= 0, projectileSize.height >= 0 else {
+            return nil
+        }
+
+        let sceneDiagonal = hypot(sceneSize.width, sceneSize.height)
+        let projectileClearance = max(projectileSize.width, projectileSize.height)
+        let distance = sceneDiagonal + projectileClearance
+        guard sceneDiagonal.isFinite, distance.isFinite, distance > 0 else {
+            return nil
+        }
+
+        return distance
+    }
 }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ unsigned simulator build when Xcode is available.
 - Enemy spawning is keyed and stopped when game-over presentation starts.
 - Background scroll movement advances per-frame from each node's current
   position until game over.
+- Projectile launches use a scene-aware exit distance so the whole node clears
+  wide and tall scene bounds before its movement action completes.
 - This is a local game sample. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
@@ -91,6 +93,8 @@ game-over transitions, unguarded game-over restarts, stale collision nodes,
 late collision handler mutations, uncleared contact delegate callbacks, late
 spawn actions, broken per-frame background scroll movement, debug logging,
 network, analytics, upload, or persistence behavior.
+The executable harness covers both finite direction normalization and
+scene-aware projectile travel for wide, tall, invalid, and overflowing geometry.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -134,6 +138,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   collision guardrail.
 - See `docs/plans/2026-06-16-executable-projectile-math-tests.md` for the shared
   projectile validation and executable Swift behavioral gate.
+- See `docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md`
+  for the scene-aware exit distance and invalid-geometry guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private var failureCount = 0
 
-private func expectNil(_ value: CGPoint?, _ message: String) {
+private func expectNil<T>(_ value: T?, _ message: String) {
     if value != nil {
         failureCount += 1
         fputs("FAIL: \(message): expected nil\n", stderr)
@@ -25,6 +25,23 @@ private func expectPoint(
         abs(actual.x - expectedX) > accuracy || abs(actual.y - expectedY) > accuracy {
         failureCount += 1
         fputs("FAIL: \(message): expected (\(expectedX), \(expectedY)), got (\(actual.x), \(actual.y))\n", stderr)
+    }
+}
+
+private func expectDistance(
+    _ actual: CGFloat?,
+    _ expected: CGFloat,
+    accuracy: CGFloat = 0.000_001,
+    _ message: String
+) {
+    guard let actual else {
+        failureCount += 1
+        fputs("FAIL: \(message): expected a distance\n", stderr)
+        return
+    }
+    if !actual.isFinite || abs(actual - expected) > accuracy {
+        failureCount += 1
+        fputs("FAIL: \(message): expected \(expected), got \(actual)\n", stderr)
     }
 }
 
@@ -51,6 +68,65 @@ expectNil(ProjectileMath.direction(offset: CGPoint(x: .infinity, y: 1.0)), "infi
 expectNil(
     ProjectileMath.direction(offset: CGPoint(x: CGFloat.greatestFiniteMagnitude, y: CGFloat.greatestFiniteMagnitude)),
     "overflowing vector lengths are rejected"
+)
+
+expectDistance(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    hypot(1366.0, 1024.0) + 40.0,
+    "wide scenes use their diagonal plus projectile clearance"
+)
+expectDistance(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 768.0, height: 1366.0),
+        projectileSize: CGSize(width: 20.0, height: 60.0)
+    ),
+    hypot(768.0, 1366.0) + 60.0,
+    "tall scenes use their diagonal plus the largest projectile dimension"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 0.0, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "zero-width scenes are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: -1.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "negative scene dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: .nan, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "non-finite scene dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: -1.0, height: 30.0)
+    ),
+    "negative projectile dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: .infinity, height: 30.0)
+    ),
+    "non-finite projectile dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+        projectileSize: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    ),
+    "overflowing exit distances are rejected"
 )
 
 if failureCount > 0 {

--- a/docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md
+++ b/docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md
@@ -1,0 +1,110 @@
+---
+title: Scene-Aware Projectile Exit Distance
+type: fix
+date: 2026-06-17
+---
+
+# Scene-Aware Projectile Exit Distance
+
+## Summary
+
+Replace the fixed 1000-point projectile travel scalar with validated geometry
+derived from the scene and projectile sizes. Extend the portable Swift harness
+so wide-scene behavior and invalid geometry are executed in CI.
+
+## Problem Frame
+
+`GameScene` claims every projectile travels far enough to leave the screen, but
+the destination is always 1000 points from the player. A wide landscape scene
+can keep that destination visibly inside its bounds, causing the projectile to
+disappear when its action completes before it reaches an edge.
+
+## Requirements
+
+- R1. Derive projectile travel distance from finite, positive scene dimensions
+  and finite, non-negative projectile dimensions.
+- R2. Return a distance greater than the scene diagonal by enough margin for
+  the projectile node to clear the scene boundary from any in-bounds origin.
+- R3. Reject invalid geometry before adding the projectile node, scheduling its
+  action, or playing the launch sound.
+- R4. Execute portable Swift cases for wide and tall scenes, projectile margin,
+  zero or negative dimensions, non-finite dimensions, and overflow.
+- R5. Preserve forward-only finite direction validation, collision masks,
+  action duration, audio behavior for valid launches, and SpriteKit metadata.
+- R6. Keep the canonical checker and project documentation aligned with the
+  scene-aware projectile distance contract.
+
+## Key Technical Decisions
+
+- **Use the scene diagonal as the base distance:** the diagonal bounds the
+  longest in-scene ray from any in-bounds origin without coupling portable math
+  to SpriteKit frame APIs.
+- **Add the projectile's largest dimension as clearance:** this moves the whole
+  node beyond the boundary instead of stopping when only its center reaches it.
+- **Keep geometry in `ProjectileMath`:** Foundation-only math remains executable
+  through the existing `swiftc` harness and is shared directly by `GameScene`.
+- **Fail closed on invalid geometry:** malformed or overflowing sizes suppress
+  the launch instead of creating a node with a non-finite destination.
+
+## Implementation Units
+
+### U1. Add validated exit-distance math
+
+- **Goal:** Calculate a finite scene-aware travel distance with projectile
+  clearance and reject invalid or overflowing sizes.
+- **Files:** `EmojiThrower/ProjectileMath.swift`
+- **Patterns:** Follow the existing optional-return finite guard used by
+  projectile direction normalization.
+- **Test Scenarios:** Wide landscape, tall portrait, margin increase, zero,
+  negative, NaN, infinity, and overflowing dimensions.
+- **Covers:** R1, R2, R4.
+
+### U2. Delegate launch distance to the shared helper
+
+- **Goal:** Require a valid exit distance before adding or animating a
+  projectile, then replace the fixed scalar with that distance.
+- **Files:** `EmojiThrower/GameScene.swift`
+- **Patterns:** Preserve the current direction guard and keep helper source in
+  the application target.
+- **Verification:** Static source ordering proves geometry validation occurs
+  before `addChild`, movement, and sound playback.
+- **Covers:** R3, R5.
+
+### U3. Extend executable and static contracts
+
+- **Goal:** Run the new geometry cases through the existing portable harness and
+  document the runtime boundary.
+- **Files:** `Tests/ProjectileMathTests/main.swift`, `scripts/check-baseline.py`,
+  `README.md`, `CHANGES.md`
+- **Patterns:** Reuse `scripts/run-projectile-math-tests.sh` and the canonical
+  `make check` path without adding a second test runner.
+- **Verification:** Root and external-directory Make gates plus isolated
+  mutations of the math, scene delegation, tests, docs, and checker contract.
+- **Covers:** R4, R6.
+
+## Risks And Mitigations
+
+- Large finite dimensions can overflow during diagonal calculation; require a
+  finite positive result before returning a distance.
+- Linux cannot exercise SpriteKit node movement; use the shared Foundation-only
+  helper locally and require hosted macOS validation for the application build.
+- The repository has a historical secret-scanning alert; do not inspect or
+  reproduce its value, and keep this change free of credentials.
+
+## Scope Boundaries
+
+- Do not change projectile direction, speed, collision behavior, scoring,
+  spawning, scene transitions, assets, sounds, signing, or dependencies.
+- Do not rewrite history or resolve the historical secret alert without owner
+  confirmation that the exposed credential was revoked or rotated.
+- Do not introduce a new test framework or duplicate the existing Swift harness.
+
+## Verification
+
+- Compile and run the portable projectile-math harness.
+- Run `make lint`, `make test`, `make build`, and `make check` from the checkout.
+- Run the absolute-path Make gate from an external directory.
+- Parse Python and project metadata, then run `git diff --check`.
+- Reject isolated mutations covering the distance formula, invalid geometry,
+  launch ordering, executable cases, documentation, and checker enforcement.
+- Audit intended files for generated artifacts and credential-shaped content.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -29,6 +29,7 @@ FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
 PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
+SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -157,6 +158,7 @@ def main():
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-stale-player-contact-guard.md",
         "docs/plans/2026-06-16-executable-projectile-math-tests.md",
+        "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md",
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
@@ -218,6 +220,7 @@ def main():
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
     projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
+    scene_aware_distance_plan = SCENE_AWARE_DISTANCE_PLAN.read_text(encoding="utf-8") if SCENE_AWARE_DISTANCE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -329,6 +332,10 @@ def main():
     projectile_sound_index = game_scene.find(
         "SKAction.playSoundFileNamed", touches_ended_index
     )
+    projectile_distance_guard_index = game_scene.find(
+        "guard let projectileTravelDistance = ProjectileMath.exitDistance(",
+        touches_ended_index,
+    )
     require(projectile_direction_index != -1 and
             "return ProjectileMath.direction(offset: offset)" in projectile_direction_body,
             "GameScene must delegate projectile validation to shared executable math",
@@ -344,6 +351,20 @@ def main():
                 f"shared projectile math must preserve finite-vector contract: {fragment}",
                 failures)
     for fragment in [
+        "static func exitDistance(sceneSize: CGSize, projectileSize: CGSize) -> CGFloat?",
+        "sceneSize.width.isFinite, sceneSize.height.isFinite",
+        "sceneSize.width > 0, sceneSize.height > 0",
+        "projectileSize.width.isFinite, projectileSize.height.isFinite",
+        "projectileSize.width >= 0, projectileSize.height >= 0",
+        "let sceneDiagonal = hypot(sceneSize.width, sceneSize.height)",
+        "let projectileClearance = max(projectileSize.width, projectileSize.height)",
+        "let distance = sceneDiagonal + projectileClearance",
+        "guard sceneDiagonal.isFinite, distance.isFinite, distance > 0",
+    ]:
+        require(fragment in projectile_math,
+                f"shared projectile math must preserve scene-aware exit distance: {fragment}",
+                failures)
+    for fragment in [
         "if !actual.x.isFinite || !actual.y.isFinite",
         "CGPoint(x: 3.0, y: 4.0)",
         "CGPoint(x: 0.0, y: 0.0)",
@@ -355,6 +376,21 @@ def main():
                 f"executable projectile behavior coverage is missing: {fragment}",
                 failures)
     for fragment in [
+        "ProjectileMath.exitDistance(",
+        "CGSize(width: 1366.0, height: 1024.0)",
+        "CGSize(width: 768.0, height: 1366.0)",
+        "hypot(1366.0, 1024.0) + 40.0",
+        "zero-width scenes are rejected",
+        "negative scene dimensions are rejected",
+        "non-finite scene dimensions are rejected",
+        "negative projectile dimensions are rejected",
+        "non-finite projectile dimensions are rejected",
+        "overflowing exit distances are rejected",
+    ]:
+        require(fragment in projectile_tests,
+                f"executable projectile exit-distance coverage is missing: {fragment}",
+                failures)
+    for fragment in [
         '"$SWIFTC"',
         '"$ROOT/EmojiThrower/ProjectileMath.swift"',
         '"$ROOT/Tests/ProjectileMathTests/main.swift"',
@@ -364,11 +400,17 @@ def main():
                 f"projectile behavior test runner is missing: {fragment}",
                 failures)
     require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
+            projectile_distance_guard_index != -1 and
             projectile_physics_index != -1 and projectile_add_index != -1 and
             projectile_sound_index != -1 and
-            touch_direction_guard_index < projectile_physics_index <
+            touch_direction_guard_index < projectile_distance_guard_index <
+            projectile_physics_index <
             projectile_add_index < projectile_sound_index,
-            "GameScene must validate projectile direction before physics, insertion, and sound",
+            "GameScene must validate projectile direction and exit geometry before physics, insertion, and sound",
+            failures)
+    require("let shootDistance = direction * projectileTravelDistance" in game_scene and
+            "direction * 1000" not in game_scene,
+            "GameScene must use scene-aware projectile travel distance instead of a fixed scalar",
             failures)
     require("projectileDidCollideWithMonster(projectile, monster: monster)" in game_scene and
             "monsterDidCollideWithPlayer(monster, player: player)" in game_scene and
@@ -469,6 +511,18 @@ def main():
     require("docs/plans/2026-06-16-executable-projectile-math-tests.md" in readme and
             "executable Swift" in readme,
             "README must document executable projectile math coverage",
+            failures)
+    require("title: Scene-Aware Projectile Exit Distance" in scene_aware_distance_plan and
+            "type: fix" in scene_aware_distance_plan and
+            "date: 2026-06-17" in scene_aware_distance_plan and
+            "R1." in scene_aware_distance_plan and "R6." in scene_aware_distance_plan and
+            "status:" not in scene_aware_distance_plan.lower(),
+            "scene-aware projectile distance plan must preserve portable metadata and requirements",
+            failures)
+    require("scene-aware exit distance" in readme.lower() and
+            "2026-06-17-020-fix-scene-aware-projectile-distance-plan.md" in readme and
+            "scene-aware" in changes.lower() and "projectile travel" in changes.lower(),
+            "README and CHANGES must document scene-aware projectile travel",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and


### PR DESCRIPTION
## Summary

Projectiles on wide landscape scenes could disappear when their fixed
1000-point action ended while the node was still visible. Launch distance now
uses the scene diagonal plus projectile clearance, so valid shots move the whole
node beyond wide or tall scene bounds before removal.

## Baseline

The previous fixed travel distance did not account for scene dimensions or the
projectile's visible clearance. Invalid or overflowing geometry also lacked an
explicit no-side-effect boundary before physics, scene insertion, movement, and
sound work began.

## Improvements

Launch distance is derived from the scene diagonal plus projectile clearance.
Invalid or overflowing scene geometry now suppresses the launch before physics,
scene insertion, movement, or sound side effects. The portable Swift harness
covers landscape, portrait, clearance, invalid dimensions, and overflow, while
the canonical checker locks the scene delegation and documentation.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- Absolute-path Make gate from `/tmp`
- Python bytecode compilation and `git diff --check`
- Seven isolated mutations rejected
- Plan-aware review found no actionable findings
- Artifact and credential-pattern audits passed

Local Linux validation truthfully skipped executable Swift and Xcode because
`swiftc` and `xcodebuild` are unavailable. The exact-head macOS push and
pull-request checks are required to compile and execute the shared Swift harness
and build the SpriteKit target.

## Risk

The main regression risk is calculating insufficient travel distance or
rejecting valid scene geometry. The focused geometry harness and exact-head
macOS checks cover those paths. Historical secret-scanning alert 1 remains open
pending owner verification that the exposed Google API key was revoked or
rotated; this change did not inspect, copy, rewrite, or modify that secret.

## Follow-Ups

No additional operational monitoring is required because this repository is a
local SpriteKit sample with no deployed service, logs, metrics, or dashboards.
Before merge, verify both canonical GitHub Actions events remain green on the
exact head. Any Swift harness or simulator-build failure is the rollback trigger,
with the branch commit reverted before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
