### PR TITLE
Guard detached game-over transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,14 @@ player launches emoji projectiles at moving targets.
 
 ## Coding conventions
 
-- Language mix noted in the README: Swift (9).
+- Language mix noted in the README: Swift (10).
 - Preserve the checked-in Swift 5, iOS 12, Xcode, and signing assumptions unless
   the change is explicitly about modernization.
 
 ## Testing guidance
 
-- No dedicated test files were detected; treat `make check` as the minimum baseline.
+- `make check` compiles and runs the shared projectile-math harness when
+  `swiftc` is available; hosted macOS is the authoritative execution boundary.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ player launches emoji projectiles at moving targets.
 - Debug logging from launch and gameplay paths should stay removed; score should remain visible in-game rather than printed to the console.
 - Runtime debug overlays should stay disabled outside explicit troubleshooting builds.
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.
+- Keep active-scene game-over ownership ahead of terminal state, spawn,
+  contact-delegate, and presentation side effects.
 - This is an Apple platform sample. Xcode, Swift, and deployment target versions
   must stay aligned with the checked-in project settings.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Skipped enemy spawning for invalid or undersized scene geometry before
+  constructing a closed random range or adding the SpriteKit node.
+
 ## 2026-06-12
 
 - Prevented duplicate queued projectile contacts from scoring after either

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected non-finite touch vectors before projectile physics, insertion,
+  movement, or sound effects.
 - Skipped enemy spawning for invalid or undersized scene geometry before
   constructing a closed random range or adding the SpriteKit node.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made all Make verification aliases location-independent when invoked through
+  an absolute Makefile path.
 - Rejected non-finite touch vectors before projectile physics, insertion,
   movement, or sound effects.
 - Skipped enemy spawning for invalid or undersized scene geometry before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-17
+
+- Replaced the fixed projectile travel scalar with validated scene-aware
+  projectile travel that includes node clearance for wide and tall scenes.
+- Extended the executable Swift harness with scene geometry, projectile margin,
+  invalid dimension, and overflow cases.
+
 ## 2026-06-16
 
 - Added executable Swift tests for projectile direction normalization using the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Ignored queued player contacts after either collision node has already left
+  the active scene.
+
 ## 2026-06-13
 
 - Made all Make verification aliases location-independent when invoked through

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-18
+
+- Required active-scene game-over ownership before terminal state changes,
+  spawn cancellation, contact shutdown, or destination presentation.
+
 ## 2026-06-17
 
 - Replaced the fixed projectile travel scalar with validated scene-aware

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Added executable Swift tests for projectile direction normalization using the
+  same finite-vector implementation as the SpriteKit scene.
+
 ## 2026-06-14
 
 - Ignored queued player contacts after either collision node has already left

--- a/EmojiThrower.xcodeproj/project.pbxproj
+++ b/EmojiThrower.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7FB5DE681D14C62600813314 /* GameOverScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE641D14C62600813314 /* GameOverScene.swift */; };
 		7FB5DE691D14C62600813314 /* GameScene.sks in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE651D14C62600813314 /* GameScene.sks */; };
 		7FB5DE6A1D14C62600813314 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE661D14C62600813314 /* GameScene.swift */; };
+		A16061611D14C62600813314 /* ProjectileMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621D14C62600813314 /* ProjectileMath.swift */; };
 		7FB5DE6B1D14C62600813314 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB5DE671D14C62600813314 /* GameViewController.swift */; };
 		7FB5DE701D14C63000813314 /* background-music-aac.caf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE6D1D14C63000813314 /* background-music-aac.caf */; };
 		7FB5DE711D14C63000813314 /* pew-pew-lei.caf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5DE6E1D14C63000813314 /* pew-pew-lei.caf */; };
@@ -34,6 +35,7 @@
 		7FB5DE641D14C62600813314 /* GameOverScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameOverScene.swift; sourceTree = "<group>"; };
 		7FB5DE651D14C62600813314 /* GameScene.sks */ = {isa = PBXFileReference; lastKnownFileType = file.sks; path = GameScene.sks; sourceTree = "<group>"; };
 		7FB5DE661D14C62600813314 /* GameScene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameScene.swift; sourceTree = "<group>"; };
+		A16061621D14C62600813314 /* ProjectileMath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectileMath.swift; sourceTree = "<group>"; };
 		7FB5DE671D14C62600813314 /* GameViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameViewController.swift; sourceTree = "<group>"; };
 		7FB5DE6D1D14C63000813314 /* background-music-aac.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "background-music-aac.caf"; sourceTree = "<group>"; };
 		7FB5DE6E1D14C63000813314 /* pew-pew-lei.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "pew-pew-lei.caf"; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				7FB5DE641D14C62600813314 /* GameOverScene.swift */,
 				7FB5DE651D14C62600813314 /* GameScene.sks */,
 				7FB5DE661D14C62600813314 /* GameScene.swift */,
+				A16061621D14C62600813314 /* ProjectileMath.swift */,
 				7FB5DE6C1D14C63000813314 /* Sounds */,
 				7FB5DE6F1D14C63000813314 /* sprites.atlas */,
 				7FB5DE601D14C5F100813314 /* Assets.xcassets */,
@@ -203,6 +206,7 @@
 				7FB5DE6B1D14C62600813314 /* GameViewController.swift in Sources */,
 				7FB5DE681D14C62600813314 /* GameOverScene.swift in Sources */,
 				7FB5DE6A1D14C62600813314 /* GameScene.swift in Sources */,
+				A16061611D14C62600813314 /* ProjectileMath.swift in Sources */,
 				7FB5DE4F1D14C5BC00813314 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -101,6 +101,20 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     func random(min: CGFloat, max: CGFloat) -> CGFloat {
         return CGFloat.random(in: min...max)
     }
+
+    func monsterSpawnY(spriteHeight: CGFloat) -> CGFloat? {
+        guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else {
+            return nil
+        }
+
+        let minY = spriteHeight / 2
+        let maxY = size.height - minY
+        guard minY <= maxY else {
+            return nil
+        }
+
+        return random(min: minY, max: maxY)
+    }
     
     //MARK: - Get Profile Picture
     func roundSquareImage(imageName: String) -> SKSpriteNode {
@@ -140,7 +154,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         
         // Determine where to spawn the monster along the Y axis
-        let actualY = random(min: monster.size.height/2, max: size.height - monster.size.height/2)
+        guard let actualY = monsterSpawnY(spriteHeight: monster.size.height) else {
+            return
+        }
         
         // Position the monster slightly off-screen along the right edge,
         // and along a random position along the Y axis as calculated above

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -115,6 +115,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
 
         return random(min: minY, max: maxY)
     }
+
+    func projectileDirection(offset: CGPoint) -> CGPoint? {
+        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
+            return nil
+        }
+
+        let offsetLength = offset.length()
+        guard offsetLength.isFinite, offsetLength > 0 else {
+            return nil
+        }
+
+        let direction = offset / offsetLength
+        guard direction.x.isFinite, direction.y.isFinite else {
+            return nil
+        }
+
+        return direction
+    }
     
     //MARK: - Get Profile Picture
     func roundSquareImage(imageName: String) -> SKSpriteNode {
@@ -237,8 +255,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Determine offset of touch location to projectile
         let offset = touchLocation - projectile.position
         
-        // Cancel shots that do not travel forward.
-        if (offset.x <= 0) { return }
+        guard let direction = projectileDirection(offset: offset) else {
+            return
+        }
         
         // Projectile collision set up
         projectile.physicsBody = SKPhysicsBody(circleOfRadius: projectile.size.width/2)
@@ -250,9 +269,6 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         // Add projectile after double-checking direction of shot
         addChild(projectile)
-        
-        // Get the direction of where to shoot
-        let direction = offset.normalized()
         
         // Make it shoot far enough to be guaranteed off screen
         let shootDistance = direction * 1000

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -117,21 +117,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     func projectileDirection(offset: CGPoint) -> CGPoint? {
-        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
-            return nil
-        }
-
-        let offsetLength = offset.length()
-        guard offsetLength.isFinite, offsetLength > 0 else {
-            return nil
-        }
-
-        let direction = offset / offsetLength
-        guard direction.x.isFinite, direction.y.isFinite else {
-            return nil
-        }
-
-        return direction
+        return ProjectileMath.direction(offset: offset)
     }
     
     //MARK: - Get Profile Picture

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -277,13 +277,18 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         run(SKAction.playSoundFileNamed("pew-pew-lei.caf", waitForCompletion: false))
     }
 
-    func presentGameOver(won: Bool, transition: SKTransition) {
-        if gameIsOver { return }
+    @discardableResult
+    func presentGameOver(won: Bool, transition: SKTransition) -> Bool {
+        guard !gameIsOver, let view = self.view, view.scene === self else {
+            return false
+        }
+
         gameIsOver = true
         removeAction(forKey: "monsterSpawn")
         physicsWorld.contactDelegate = nil
         let gameOverScene = GameOverScene(size: self.size, won: won)
-        self.view?.presentScene(gameOverScene, transition: transition)
+        view.presentScene(gameOverScene, transition: transition)
+        return true
     }
     
     //MARK: - Projectile Collision Actions

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -244,6 +244,12 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         guard let direction = projectileDirection(offset: offset) else {
             return
         }
+        guard let projectileTravelDistance = ProjectileMath.exitDistance(
+            sceneSize: size,
+            projectileSize: projectile.size
+        ) else {
+            return
+        }
         
         // Projectile collision set up
         projectile.physicsBody = SKPhysicsBody(circleOfRadius: projectile.size.width/2)
@@ -256,8 +262,8 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         // Add projectile after double-checking direction of shot
         addChild(projectile)
         
-        // Make it shoot far enough to be guaranteed off screen
-        let shootDistance = direction * 1000
+        // Make it shoot far enough to move the whole node off screen.
+        let shootDistance = direction * projectileTravelDistance
         
         // Add the shoot amount to the current position
         let realDest = shootDistance + projectile.position

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -314,6 +314,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     }
     func monsterDidCollideWithPlayer(_ monster:SKSpriteNode, player:SKSpriteNode) {
         if gameIsOver { return }
+        guard monster.parent === self, player.parent === self else { return }
 
         playerDestroyed = true
 

--- a/EmojiThrower/ProjectileMath.swift
+++ b/EmojiThrower/ProjectileMath.swift
@@ -18,4 +18,22 @@ enum ProjectileMath {
 
         return direction
     }
+
+    static func exitDistance(sceneSize: CGSize, projectileSize: CGSize) -> CGFloat? {
+        guard sceneSize.width.isFinite, sceneSize.height.isFinite,
+              sceneSize.width > 0, sceneSize.height > 0,
+              projectileSize.width.isFinite, projectileSize.height.isFinite,
+              projectileSize.width >= 0, projectileSize.height >= 0 else {
+            return nil
+        }
+
+        let sceneDiagonal = hypot(sceneSize.width, sceneSize.height)
+        let projectileClearance = max(projectileSize.width, projectileSize.height)
+        let distance = sceneDiagonal + projectileClearance
+        guard sceneDiagonal.isFinite, distance.isFinite, distance > 0 else {
+            return nil
+        }
+
+        return distance
+    }
 }

--- a/EmojiThrower/ProjectileMath.swift
+++ b/EmojiThrower/ProjectileMath.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum ProjectileMath {
+    static func direction(offset: CGPoint) -> CGPoint? {
+        guard offset.x.isFinite, offset.y.isFinite, offset.x > 0 else {
+            return nil
+        }
+
+        let offsetLength = sqrt(offset.x * offset.x + offset.y * offset.y)
+        guard offsetLength.isFinite, offsetLength > 0 else {
+            return nil
+        }
+
+        let direction = CGPoint(x: offset.x / offsetLength, y: offset.y / offsetLength)
+        guard direction.x.isFinite, direction.y.isFinite else {
+            return nil
+        }
+
+        return direction
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
+	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 .PHONY: build check lint test
 
+SWIFTC ?= swiftc
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 
 check:
+	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-projectile-math-tests.sh"; \
+	else \
+		echo "swiftc unavailable; executable projectile math tests skipped"; \
+	fi
 	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Debug logging from launch and gameplay paths should stay removed; score should remain visible in-game rather than printed to the console.
 - Runtime debug overlays should stay disabled outside explicit troubleshooting builds.
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.
+- Enemy spawning skips invalid or undersized scene geometry before constructing
+  a random range or adding a SpriteKit node.
 
 ## Maintenance Notes
 
@@ -118,6 +120,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-09-collision-handler-game-over-guard.md` for the collision handler guardrail.
 - See `docs/plans/2026-06-09-contact-delegate-game-over-guard.md` for the contact delegate game-over guardrail.
 - See `docs/plans/2026-06-10-game-over-restart-guard.md` for the game-over restart guardrail.
+- See `docs/plans/2026-06-13-undersized-scene-spawn-guard.md` for the enemy
+  spawn geometry guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-10-swift-5-spritekit-build.md` for the Swift 5
   simulator-build migration.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, plist/storyboard files, SpriteKit assets, sounds, fonts, Xcode metadata, or gameplay/privacy documentation.
+- The same gates may be invoked through an absolute Makefile path from another
+  directory; verification resolves the checker relative to the checkout.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, stale collision nodes, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -122,6 +122,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-10-game-over-restart-guard.md` for the game-over restart guardrail.
 - See `docs/plans/2026-06-13-undersized-scene-spawn-guard.md` for the enemy
   spawn geometry guardrail.
+- See `docs/plans/2026-06-14-stale-player-contact-guard.md` for the stale player
+  collision guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `garethpaul/ios-emoji-thrower` is a Swift 5 SpriteKit game sample in which the
 player launches emoji projectiles at moving targets.
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (9).
+This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (10).
 
 ## Repository Contents
 
@@ -82,7 +82,15 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/asset metadata, validates the binary SpriteKit scene plist, checks Xcode resource references, verifies the Swift source inventory, and guards against image-helper force unwraps, non-finite touch vectors, repeated game-over transitions, unguarded game-over restarts, stale collision nodes, late collision handler mutations, uncleared contact delegate callbacks, late spawn actions, broken per-frame background scroll movement, debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs executable Swift projectile-math tests when `swiftc` is
+available, then runs `scripts/check-baseline.py`. It parses
+plist/storyboard/asset metadata, validates the binary SpriteKit scene plist,
+checks Xcode resource references, verifies the Swift source inventory, and
+guards against image-helper force unwraps, non-finite touch vectors, repeated
+game-over transitions, unguarded game-over restarts, stale collision nodes,
+late collision handler mutations, uncleared contact delegate callbacks, late
+spawn actions, broken per-frame background scroll movement, debug logging,
+network, analytics, upload, or persistence behavior.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -124,6 +132,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   spawn geometry guardrail.
 - See `docs/plans/2026-06-14-stale-player-contact-guard.md` for the stale player
   collision guardrail.
+- See `docs/plans/2026-06-16-executable-projectile-math-tests.md` for the shared
+  projectile validation and executable Swift behavioral gate.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ unsigned simulator build when Xcode is available.
 - The game uses SpriteKit scene logic, bundled image resources, sound files, and `Sketch3D.otf`.
 - Win and loss paths share a guarded game-over presenter so contacts do not trigger repeated scene transitions.
 - Game-over restarts confirm the current scene before presenting a fresh game scene.
+- Active-scene game-over ownership is required before the outgoing scene
+  cancels gameplay or presents its terminal destination.
 - Collision handlers ignore late callbacks after game-over presentation begins.
 - The game-over presenter clears the physics contact delegate before scene transition.
 - Enemy spawning is keyed and stopped when game-over presentation starts.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ unsigned simulator build when Xcode is available.
 - Enemy spawning is keyed and stopped when game-over presentation starts.
 - Background scroll movement advances per-frame from each node's current
   position until game over.
+- Projectile launches use a scene-aware exit distance so the whole node clears
+  wide and tall scene bounds before its movement action completes.
 - This is a local game sample. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
@@ -91,6 +93,8 @@ game-over transitions, unguarded game-over restarts, stale collision nodes,
 late collision handler mutations, uncleared contact delegate callbacks, late
 spawn actions, broken per-frame background scroll movement, debug logging,
 network, analytics, upload, or persistence behavior.
+The executable harness covers both finite direction normalization and
+scene-aware projectile travel for wide, tall, invalid, and overflowing geometry.
 
 The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
 available, the baseline also compiles an unsigned Swift 5 Debug build for the
@@ -134,6 +138,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   collision guardrail.
 - See `docs/plans/2026-06-16-executable-projectile-math-tests.md` for the shared
   projectile validation and executable Swift behavioral gate.
+- See `docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md`
+  for the scene-aware exit distance and invalid-geometry guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
-- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
-- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,8 @@ Helpful reports include:
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
 - `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- Active-scene game-over ownership prevents detached scenes from mutating
+  terminal gameplay state without an authoritative presentation target.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -40,7 +40,10 @@ expectPoint(
     y: -0.8,
     "negative vertical offsets preserve direction"
 )
-expectNil(ProjectileMath.direction(offset: .zero), "zero-length offsets are rejected")
+expectNil(
+    ProjectileMath.direction(offset: CGPoint(x: 0.0, y: 0.0)),
+    "zero-length offsets are rejected"
+)
 expectNil(ProjectileMath.direction(offset: CGPoint(x: -1.0, y: 0.0)), "backward offsets are rejected")
 expectNil(ProjectileMath.direction(offset: CGPoint(x: .nan, y: 1.0)), "NaN horizontal offsets are rejected")
 expectNil(ProjectileMath.direction(offset: CGPoint(x: 1.0, y: .nan)), "NaN vertical offsets are rejected")

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+private var failureCount = 0
+
+private func expectNil(_ value: CGPoint?, _ message: String) {
+    if value != nil {
+        failureCount += 1
+        fputs("FAIL: \(message): expected nil\n", stderr)
+    }
+}
+
+private func expectPoint(
+    _ actual: CGPoint?,
+    x expectedX: CGFloat,
+    y expectedY: CGFloat,
+    accuracy: CGFloat = 0.000_001,
+    _ message: String
+) {
+    guard let actual else {
+        failureCount += 1
+        fputs("FAIL: \(message): expected a direction\n", stderr)
+        return
+    }
+    if !actual.x.isFinite || !actual.y.isFinite ||
+        abs(actual.x - expectedX) > accuracy || abs(actual.y - expectedY) > accuracy {
+        failureCount += 1
+        fputs("FAIL: \(message): expected (\(expectedX), \(expectedY)), got (\(actual.x), \(actual.y))\n", stderr)
+    }
+}
+
+expectPoint(
+    ProjectileMath.direction(offset: CGPoint(x: 3.0, y: 4.0)),
+    x: 0.6,
+    y: 0.8,
+    "finite forward offsets normalize to unit direction"
+)
+expectPoint(
+    ProjectileMath.direction(offset: CGPoint(x: 3.0, y: -4.0)),
+    x: 0.6,
+    y: -0.8,
+    "negative vertical offsets preserve direction"
+)
+expectNil(ProjectileMath.direction(offset: .zero), "zero-length offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: -1.0, y: 0.0)), "backward offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: .nan, y: 1.0)), "NaN horizontal offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: 1.0, y: .nan)), "NaN vertical offsets are rejected")
+expectNil(ProjectileMath.direction(offset: CGPoint(x: .infinity, y: 1.0)), "infinite offsets are rejected")
+expectNil(
+    ProjectileMath.direction(offset: CGPoint(x: CGFloat.greatestFiniteMagnitude, y: CGFloat.greatestFiniteMagnitude)),
+    "overflowing vector lengths are rejected"
+)
+
+if failureCount > 0 {
+    exit(1)
+}
+
+print("ProjectileMath behavioral tests passed")

--- a/Tests/ProjectileMathTests/main.swift
+++ b/Tests/ProjectileMathTests/main.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private var failureCount = 0
 
-private func expectNil(_ value: CGPoint?, _ message: String) {
+private func expectNil<T>(_ value: T?, _ message: String) {
     if value != nil {
         failureCount += 1
         fputs("FAIL: \(message): expected nil\n", stderr)
@@ -25,6 +25,23 @@ private func expectPoint(
         abs(actual.x - expectedX) > accuracy || abs(actual.y - expectedY) > accuracy {
         failureCount += 1
         fputs("FAIL: \(message): expected (\(expectedX), \(expectedY)), got (\(actual.x), \(actual.y))\n", stderr)
+    }
+}
+
+private func expectDistance(
+    _ actual: CGFloat?,
+    _ expected: CGFloat,
+    accuracy: CGFloat = 0.000_001,
+    _ message: String
+) {
+    guard let actual else {
+        failureCount += 1
+        fputs("FAIL: \(message): expected a distance\n", stderr)
+        return
+    }
+    if !actual.isFinite || abs(actual - expected) > accuracy {
+        failureCount += 1
+        fputs("FAIL: \(message): expected \(expected), got \(actual)\n", stderr)
     }
 }
 
@@ -51,6 +68,65 @@ expectNil(ProjectileMath.direction(offset: CGPoint(x: .infinity, y: 1.0)), "infi
 expectNil(
     ProjectileMath.direction(offset: CGPoint(x: CGFloat.greatestFiniteMagnitude, y: CGFloat.greatestFiniteMagnitude)),
     "overflowing vector lengths are rejected"
+)
+
+expectDistance(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    hypot(1366.0, 1024.0) + 40.0,
+    "wide scenes use their diagonal plus projectile clearance"
+)
+expectDistance(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 768.0, height: 1366.0),
+        projectileSize: CGSize(width: 20.0, height: 60.0)
+    ),
+    hypot(768.0, 1366.0) + 60.0,
+    "tall scenes use their diagonal plus the largest projectile dimension"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 0.0, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "zero-width scenes are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: -1.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "negative scene dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: .nan, height: 1024.0),
+        projectileSize: CGSize(width: 40.0, height: 30.0)
+    ),
+    "non-finite scene dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: -1.0, height: 30.0)
+    ),
+    "negative projectile dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: 1366.0, height: 1024.0),
+        projectileSize: CGSize(width: .infinity, height: 30.0)
+    ),
+    "non-finite projectile dimensions are rejected"
+)
+expectNil(
+    ProjectileMath.exitDistance(
+        sceneSize: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+        projectileSize: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    ),
+    "overflowing exit distances are rejected"
 )
 
 if failureCount > 0 {

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Stop enemy spawning as soon as game-over presentation starts
 - Skip enemy spawning when invalid or undersized scene geometry cannot contain
   the monster sprite
+- Reject non-finite touch vectors before projectile side effects
 - Keep background scroll movement running per-frame until game over
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,8 @@ Priority:
 - Keep collision handlers from mutating score or player state after game over
 - Clear the physics contact delegate before game-over scene transitions
 - Stop enemy spawning as soon as game-over presentation starts
+- Skip enemy spawning when invalid or undersized scene geometry cannot contain
+  the monster sprite
 - Keep background scroll movement running per-frame until game over
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode
@@ -65,7 +67,7 @@ Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 metadata, bundled resource references, SpriteKit scene sources, image helper
 fallbacks, game-over transition guards, game-over restart handling, collision
 handler game-over guards, contact delegate cleanup, spawn lifecycle guards,
-per-frame background scroll movement, and local-only gameplay with no debug
+undersized scene spawn geometry, per-frame background scroll movement, and local-only gameplay with no debug
 logging, network, analytics, upload, or persistence behavior.
 On macOS, the baseline should compile an unsigned simulator build without
 rendering frames, playing audio, simulating physics, or running gameplay.

--- a/VISION.md
+++ b/VISION.md
@@ -22,6 +22,8 @@ Priority:
 - Keep optional image helper rendering tolerant of missing assets
 - Keep game-over transitions guarded against repeated contact handling
 - Keep delayed game-over restarts tied to the current SpriteKit scene
+- Require active-scene game-over ownership before terminal scene mutation or
+  transition presentation
 - Keep collision handlers from mutating score or player state after game over
 - Clear the physics contact delegate before game-over scene transitions
 - Stop enemy spawning as soon as game-over presentation starts

--- a/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
+++ b/docs/plans/2026-06-12-projectile-duplicate-contact-guard.md
@@ -9,7 +9,7 @@ one physics step. `projectileDidCollideWithMonster` increments score before
 checking whether the projectile or monster was already removed, so one shot can
 score more than once when contacts overlap.
 
-## Completed Scope
+## Work Completed
 
 - Require both collision nodes to remain attached to the active scene before
   mutating score.
@@ -17,10 +17,25 @@ score more than once when contacts overlap.
 - Preserve the existing game-over guard and 20-hit win threshold.
 - Extend the static baseline with node-lifecycle ordering contracts.
 
-## Verification
+## Verification Completed
 
-- `make check`
-- `git diff --check`
-- Mutations removing the active-node guard or moving score mutation before node
-  removal must fail the baseline.
-- Hosted macOS validation must build the Swift 5 SpriteKit sample.
+- Local `make check`, `make lint`, `make test`, and `make build` passed. The
+  local environment did not provide `xcodebuild`, so these runs exercised the
+  complete static baseline and reported the hosted Xcode requirement.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Hostile mutations changing the plan status, inserting an unfinished-work
+  marker, falsifying a run ID, removing the active-node predicate, or moving
+  score mutation before node removal were rejected by the baseline.
+- The implementation push Check run `27394998651` completed successfully for
+  commit `560e645d46cd073f7d062719c486e022e0d79611`.
+- The implementation pull-request Check run `27395002711` completed
+  successfully for commit `560e645d46cd073f7d062719c486e022e0d79611` and
+  built the Swift 5 SpriteKit sample on hosted macOS.
+- The post-merge push Check run `27395075194` completed successfully for
+  commit `8ce9716ffb4a523612fad6a401a326b2d17b22ac`.
+- The CodeQL setup run `27402323210` completed successfully for commit
+  `8ce9716ffb4a523612fad6a401a326b2d17b22ac`.
+- The collision handler preserves
+  `guard projectile.parent === self, monster.parent === self else { return }`
+  and removes both nodes before `monstersDestroyed += 1`.

--- a/docs/plans/2026-06-13-finite-projectile-touch-vector.md
+++ b/docs/plans/2026-06-13-finite-projectile-touch-vector.md
@@ -1,6 +1,6 @@
 # Finite Projectile Touch Vector Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,3 +40,30 @@ before the projectile is removed.
 - Hostile mutations must reject missing component or length finiteness checks,
   acceptance of non-forward vectors, direction validation after node insertion,
   stale plan status, and missing verification evidence.
+
+## Work Completed
+
+- Added a pure optional direction helper that rejects non-finite components,
+  non-forward offsets, and zero, non-finite, or overflowed lengths.
+- Required the normalized direction itself to remain finite before returning it.
+- Moved direction validation before projectile physics, node insertion,
+  movement, and sound effects.
+- Documented the finite touch-vector boundary without changing gameplay tuning,
+  resources, project files, or workflow policy.
+
+## Verification Completed
+
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, plist, XML, and workflow YAML parsing,
+  and `git diff --check` passed.
+- Seven isolated hostile mutations were rejected: removed horizontal component
+  finiteness, removed vertical component finiteness, removed length finiteness,
+  accepted non-forward vectors, validated after node insertion, stale plan
+  status, and missing verification evidence.
+- Exact-base comparison confirmed project files, bundled resources, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact, secret-pattern, and forbidden data-flow
+  scans passed.
+- Hosted macOS simulator compilation and code-scanning evidence is recorded
+  separately after push; this plan claims only completed local static evidence.

--- a/docs/plans/2026-06-13-finite-projectile-touch-vector.md
+++ b/docs/plans/2026-06-13-finite-projectile-touch-vector.md
@@ -1,0 +1,42 @@
+# Finite Projectile Touch Vector Guard
+
+status: planned
+
+## Context
+
+Projectile launching rejects non-forward touches, but a NaN horizontal offset
+makes the `<= 0` comparison false. Non-finite or overflow-length touch vectors
+can then propagate through normalization into SpriteKit positions and actions
+before the projectile is removed.
+
+## Requirements
+
+- R1. Reject non-finite horizontal and vertical touch offsets.
+- R2. Reject non-forward offsets and zero, non-finite, or overflowed vector
+  lengths before normalization.
+- R3. Return a finite normalized direction only for valid forward vectors.
+- R4. Validate direction before projectile physics, node insertion, movement,
+  or sound effects.
+- R5. Preserve ordinary forward-shot behavior, game-over guards, collision
+  handling, and local-only gameplay.
+
+## Scope Boundaries
+
+- Do not change projectile speed, distance, image, physics categories, sound, or
+  collision scoring.
+- Do not add network, persistence, analytics, authentication, or remote assets.
+- Do not modify project files, bundled resources, or hosted workflow policy.
+- Local Linux validation must remain truthful about unavailable `xcodebuild`.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- plist, XML, and workflow YAML parsing
+- `git diff --check`
+- Hostile mutations must reject missing component or length finiteness checks,
+  acceptance of non-forward vectors, direction validation after node insertion,
+  stale plan status, and missing verification evidence.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,13 +1,13 @@
 # Location-Independent Emoji Thrower Verification
 
-status: in progress
+status: completed
 
 ## Context
 
-Absolute Makefile invocations currently resolve `scripts/check-baseline.py`
-relative to the caller instead of the checkout. This makes the documented
+Absolute Makefile invocations previously resolved `scripts/check-baseline.py`
+relative to the caller instead of the checkout. That made the documented
 verification aliases fail outside the repository directory even though the
-checker itself already derives the checkout root from its own path.
+checker itself already derived the checkout root from its own path.
 
 ## Scope
 
@@ -26,6 +26,24 @@ checker itself already derives the checkout root from its own path.
   documentation mutations independently.
 - Inspect intended paths, secret patterns, conflict markers, and generated
   artifacts before commit.
+
+## Work Completed
+
+- Derived the checkout root from the loaded Makefile and invoked the baseline
+  checker by absolute path.
+- Added exact Makefile, completed-plan, external-run, and synchronized guidance
+  contracts without changing gameplay, project, resource, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- All four Make gates passed from `/tmp` through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Local validation reported that `xcodebuild` was unavailable and therefore ran
+  the static iOS baseline only.
+- Five isolated hostile mutations were rejected: root derivation, checker
+  invocation, plan status, plan evidence, and documentation guidance.
 
 ## Risk And Rollback
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,33 @@
+# Location-Independent Emoji Thrower Verification
+
+status: in progress
+
+## Context
+
+Absolute Makefile invocations currently resolve `scripts/check-baseline.py`
+relative to the caller instead of the checkout. This makes the documented
+verification aliases fail outside the repository directory even though the
+checker itself already derives the checkout root from its own path.
+
+## Scope
+
+1. Derive the checkout root from the loaded Makefile.
+2. Invoke the baseline checker from that root for every Make alias.
+3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
+4. Preserve SpriteKit behavior, project metadata, resources, and workflow
+   policy.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through an absolute Makefile
+  path from a temporary directory.
+- Run checker compilation, project metadata parsing, and diff checks.
+- Reject root-derivation, checker-invocation, plan-status, plan-evidence, and
+  documentation mutations independently.
+- Inspect intended paths, secret patterns, conflict markers, and generated
+  artifacts before commit.
+
+## Risk And Rollback
+
+This changes verification path resolution only. Rollback restores the relative
+Make recipe and removes its checker, plan, and documentation contracts.

--- a/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
+++ b/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
@@ -1,0 +1,67 @@
+# Undersized Scene Spawn Guard
+
+status: planned
+
+## Context
+
+`addMonster()` builds a closed random Y range from half the monster height to
+the scene height minus half the monster height. If the SpriteKit scene is
+temporarily smaller than the sprite, that range is inverted and
+`CGFloat.random(in:)` traps before the spawn can be skipped.
+
+## Priority
+
+Scene dimensions can be transient during presentation, resizing, previews, or
+future tests. Enemy scheduling should tolerate an unusable layout frame without
+crashing the local game loop.
+
+## Requirements
+
+- R1. Calculate monster spawn Y through one helper that returns an optional.
+- R2. Reject non-finite scene or sprite heights, non-positive sprite height, and
+  scenes shorter than the sprite before constructing a random range.
+- R3. `addMonster()` must return before adding a node, physics, movement, or
+  sound when no valid Y position exists.
+- R4. Valid scenes must preserve the existing uniform closed-range placement.
+- R5. Preserve game-over spawn guards, spawn action keys, speed range, physics,
+  scoring, contacts, transitions, assets, and local-only behavior.
+- R6. Add method-scoped static contracts and completed verification evidence.
+
+## Implementation Units
+
+### U1. Validate vertical spawn geometry
+
+- **File:** `EmojiThrower/GameScene.swift`
+- Add an optional spawn-Y helper and guard its result before node insertion.
+
+### U2. Enforce crash-safe ordering
+
+- **File:** `scripts/check-baseline.py`
+- Require finite and positive inputs, ordered range validation, optional return,
+  and guard-before-`addChild` placement.
+
+### U3. Document the SpriteKit boundary
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record that undersized or invalid scenes skip enemy spawning.
+
+## Scope Boundaries
+
+- Do not change normal scene dimensions, monster assets, speed, cadence,
+  collision masks, score thresholds, or game-over behavior.
+- Do not add persistence, telemetry, networking, analytics, or a new test target.
+- Do not claim interactive gameplay validation without Xcode.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- Parse plist, storyboard, workspace, project, and workflow metadata with all
+  available local parsers.
+- `git diff --check`
+- Hostile mutations removing finite, positive, or ordered-range validation,
+  optional failure, guard-before-add ordering, plan status, or verification
+  evidence must be rejected.

--- a/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
+++ b/docs/plans/2026-06-13-undersized-scene-spawn-guard.md
@@ -1,6 +1,6 @@
 # Undersized Scene Spawn Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -52,16 +52,24 @@ crashing the local game loop.
 - Do not add persistence, telemetry, networking, analytics, or a new test target.
 - Do not claim interactive gameplay validation without Xcode.
 
-## Verification
+## Work Completed
 
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- `python3 -m py_compile scripts/check-baseline.py`
-- Parse plist, storyboard, workspace, project, and workflow metadata with all
-  available local parsers.
-- `git diff --check`
-- Hostile mutations removing finite, positive, or ordered-range validation,
-  optional failure, guard-before-add ordering, plan status, or verification
-  evidence must be rejected.
+- Added an optional spawn-Y helper that rejects non-finite, non-positive, and
+  undersized scene geometry before constructing a closed random range.
+- Guarded the helper result before the monster enters the scene or receives
+  physics and movement behavior.
+- Added method-scoped static contracts and documented the boundary.
+
+## Verification Completed
+
+- All four Make gates, `make lint`, `make test`, `make build`, and `make check`,
+  passed against the complete static baseline.
+- `python3 -m py_compile scripts/check-baseline.py`, plist parsing, storyboard
+  and workspace XML parsing, workflow YAML parsing, and `git diff --check`
+  passed.
+- Eight hostile mutations removing either finite check, the positive-height
+  check, ordered-range validation, the optional helper contract,
+  guard-before-add ordering, completed plan status, or verification evidence
+  were rejected.
+- The local environment did not provide `xcodebuild`, so interactive SpriteKit
+  gameplay, rendering, audio, and physics execution were not claimed.

--- a/docs/plans/2026-06-14-stale-player-contact-guard.md
+++ b/docs/plans/2026-06-14-stale-player-contact-guard.md
@@ -1,0 +1,42 @@
+# Stale Player Contact Guard
+
+status: planned
+
+## Context
+
+SpriteKit can deliver multiple contacts involving the same monster during one
+physics step. A projectile contact removes the monster, but a queued player
+contact can still reach `monsterDidCollideWithPlayer` and end the game even
+though that monster is no longer active in the scene.
+
+## Requirements
+
+- Require both the monster and player to remain attached to the active scene
+  before mutating player state or presenting game over.
+- Preserve the existing game-over guard, loss transition, projectile scoring,
+  and 20-hit win threshold.
+- Extend the static baseline with an ordering contract that rejects a missing
+  or late active-node guard.
+- Keep project files, bundled assets, gameplay tuning, and workflow policy
+  unchanged.
+
+## Implementation
+
+- Add an active-node guard at the start of the player collision handler after
+  the existing game-over check.
+- Update `scripts/check-baseline.py` to require the guard before player state
+  mutation and node removal.
+- Synchronize verification documentation after all local gates and hostile
+  mutations complete.
+
+## Verification
+
+- Run the focused static baseline and all Make gates from the repository.
+- Run the full gate through an absolute Makefile path from an external working
+  directory.
+- Compile the Python checker and validate shell, project, plist, XML, and
+  workflow syntax where supported.
+- Prove hostile mutations are rejected for the active-node predicate, guard
+  ordering, checker discovery, plan status, and verification evidence.
+- Audit the exact diff, generated artifacts, and intended files for secret
+  patterns before committing.

--- a/docs/plans/2026-06-14-stale-player-contact-guard.md
+++ b/docs/plans/2026-06-14-stale-player-contact-guard.md
@@ -1,6 +1,6 @@
 # Stale Player Contact Guard
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,3 +40,24 @@ though that monster is no longer active in the scene.
   ordering, checker discovery, plan status, and verification evidence.
 - Audit the exact diff, generated artifacts, and intended files for secret
   patterns before committing.
+
+## Work Completed
+
+- Required both collision nodes to remain attached to the active scene before
+  the player collision handler mutates state or presents the loss scene.
+- Extended the static baseline with guard-presence and ordering assertions.
+- Updated the README and changelog to describe the stale-contact boundary.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout and reported that `xcodebuild` was unavailable,
+  so this Linux host exercised the complete static baseline.
+- The full gate passed from an external directory through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py`, shell syntax, plist, XML,
+  project, and workflow parsing, and `git diff --check` passed.
+- Five isolated hostile mutations were rejected: missing active-node guard,
+  late guard ordering, missing plan discovery, stale plan status, and missing
+  verification evidence.
+- Exact intended-file generated-artifact and secret-pattern audits passed.
+- Hosted macOS simulator compilation and code-scanning evidence is recorded
+  separately after push; this plan claims only completed local evidence.

--- a/docs/plans/2026-06-16-executable-projectile-math-tests.md
+++ b/docs/plans/2026-06-16-executable-projectile-math-tests.md
@@ -1,0 +1,28 @@
+# Executable Projectile Math Tests
+
+Status: Completed
+
+## Goal
+
+Replace static-only confidence in projectile direction validation with
+executable Swift tests of the same implementation used by `GameScene`.
+
+## Implementation
+
+- Move finite, forward-only direction normalization into a Foundation-only
+  `ProjectileMath` helper.
+- Keep SpriteKit scene orchestration unchanged while delegating deterministic
+  vector validation to the shared helper.
+- Compile the helper and a repository-owned Swift harness through `make check`
+  whenever `swiftc` is available.
+- Keep the hosted macOS gate responsible for executable tests and the existing
+  unsigned iOS Simulator application build.
+
+## Verification
+
+- Repository and external-directory `make check` passed with explicit local
+  Swift/Xcode toolchain boundaries.
+- The harness covers finite normalization, downward shots, zero-length and
+  backward offsets, NaN and infinity, and overflowing vector lengths.
+- Hostile mutations were rejected for runner invocation, app delegation,
+  finite-vector guards, behavioral assertions, and Xcode source membership.

--- a/docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md
+++ b/docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md
@@ -1,0 +1,110 @@
+---
+title: Scene-Aware Projectile Exit Distance
+type: fix
+date: 2026-06-17
+---
+
+# Scene-Aware Projectile Exit Distance
+
+## Summary
+
+Replace the fixed 1000-point projectile travel scalar with validated geometry
+derived from the scene and projectile sizes. Extend the portable Swift harness
+so wide-scene behavior and invalid geometry are executed in CI.
+
+## Problem Frame
+
+`GameScene` claims every projectile travels far enough to leave the screen, but
+the destination is always 1000 points from the player. A wide landscape scene
+can keep that destination visibly inside its bounds, causing the projectile to
+disappear when its action completes before it reaches an edge.
+
+## Requirements
+
+- R1. Derive projectile travel distance from finite, positive scene dimensions
+  and finite, non-negative projectile dimensions.
+- R2. Return a distance greater than the scene diagonal by enough margin for
+  the projectile node to clear the scene boundary from any in-bounds origin.
+- R3. Reject invalid geometry before adding the projectile node, scheduling its
+  action, or playing the launch sound.
+- R4. Execute portable Swift cases for wide and tall scenes, projectile margin,
+  zero or negative dimensions, non-finite dimensions, and overflow.
+- R5. Preserve forward-only finite direction validation, collision masks,
+  action duration, audio behavior for valid launches, and SpriteKit metadata.
+- R6. Keep the canonical checker and project documentation aligned with the
+  scene-aware projectile distance contract.
+
+## Key Technical Decisions
+
+- **Use the scene diagonal as the base distance:** the diagonal bounds the
+  longest in-scene ray from any in-bounds origin without coupling portable math
+  to SpriteKit frame APIs.
+- **Add the projectile's largest dimension as clearance:** this moves the whole
+  node beyond the boundary instead of stopping when only its center reaches it.
+- **Keep geometry in `ProjectileMath`:** Foundation-only math remains executable
+  through the existing `swiftc` harness and is shared directly by `GameScene`.
+- **Fail closed on invalid geometry:** malformed or overflowing sizes suppress
+  the launch instead of creating a node with a non-finite destination.
+
+## Implementation Units
+
+### U1. Add validated exit-distance math
+
+- **Goal:** Calculate a finite scene-aware travel distance with projectile
+  clearance and reject invalid or overflowing sizes.
+- **Files:** `EmojiThrower/ProjectileMath.swift`
+- **Patterns:** Follow the existing optional-return finite guard used by
+  projectile direction normalization.
+- **Test Scenarios:** Wide landscape, tall portrait, margin increase, zero,
+  negative, NaN, infinity, and overflowing dimensions.
+- **Covers:** R1, R2, R4.
+
+### U2. Delegate launch distance to the shared helper
+
+- **Goal:** Require a valid exit distance before adding or animating a
+  projectile, then replace the fixed scalar with that distance.
+- **Files:** `EmojiThrower/GameScene.swift`
+- **Patterns:** Preserve the current direction guard and keep helper source in
+  the application target.
+- **Verification:** Static source ordering proves geometry validation occurs
+  before `addChild`, movement, and sound playback.
+- **Covers:** R3, R5.
+
+### U3. Extend executable and static contracts
+
+- **Goal:** Run the new geometry cases through the existing portable harness and
+  document the runtime boundary.
+- **Files:** `Tests/ProjectileMathTests/main.swift`, `scripts/check-baseline.py`,
+  `README.md`, `CHANGES.md`
+- **Patterns:** Reuse `scripts/run-projectile-math-tests.sh` and the canonical
+  `make check` path without adding a second test runner.
+- **Verification:** Root and external-directory Make gates plus isolated
+  mutations of the math, scene delegation, tests, docs, and checker contract.
+- **Covers:** R4, R6.
+
+## Risks And Mitigations
+
+- Large finite dimensions can overflow during diagonal calculation; require a
+  finite positive result before returning a distance.
+- Linux cannot exercise SpriteKit node movement; use the shared Foundation-only
+  helper locally and require hosted macOS validation for the application build.
+- The repository has a historical secret-scanning alert; do not inspect or
+  reproduce its value, and keep this change free of credentials.
+
+## Scope Boundaries
+
+- Do not change projectile direction, speed, collision behavior, scoring,
+  spawning, scene transitions, assets, sounds, signing, or dependencies.
+- Do not rewrite history or resolve the historical secret alert without owner
+  confirmation that the exposed credential was revoked or rotated.
+- Do not introduce a new test framework or duplicate the existing Swift harness.
+
+## Verification
+
+- Compile and run the portable projectile-math harness.
+- Run `make lint`, `make test`, `make build`, and `make check` from the checkout.
+- Run the absolute-path Make gate from an external directory.
+- Parse Python and project metadata, then run `git diff --check`.
+- Reject isolated mutations covering the distance formula, invalid geometry,
+  launch ordering, executable cases, documentation, and checker enforcement.
+- Audit intended files for generated artifacts and credential-shaped content.

--- a/docs/plans/2026-06-18-active-game-over-presentation.md
+++ b/docs/plans/2026-06-18-active-game-over-presentation.md
@@ -1,0 +1,94 @@
+# Active Game-Over Presentation
+
+status: planned
+
+## Context
+
+`presentGameOver` marks the scene terminal, cancels monster spawning, and clears
+the physics contact delegate before optionally presenting the next scene. If a
+late callback reaches a scene that is no longer the `SKView`'s active scene,
+those side effects still occur even though no game-over transition can be
+presented.
+
+## Priority
+
+Keep terminal scene mutation coupled to authoritative presentation ownership.
+The project already applies the equivalent active-scene guard when restarting
+from `GameOverScene`; the outgoing transition should fail closed at the same
+boundary.
+
+## Requirements
+
+- R1. Game-over presentation must require a non-nil `SKView` whose active scene
+  is the current `GameScene`.
+- R2. Ownership validation must occur before setting `gameIsOver`, cancelling
+  spawning, clearing the contact delegate, or creating the destination scene.
+- R3. An already terminal scene must continue rejecting duplicate transitions.
+- R4. Valid win and loss paths must preserve their existing transitions,
+  scoring, collision guards, and scene size.
+- R5. The presenter must report whether it accepted the transition so the
+  ownership boundary remains directly testable and reviewable.
+- R6. Portable static contracts must reject a missing, weakened, or late guard
+  and incomplete plan or guidance evidence.
+
+## Implementation Units
+
+### U1. Guard terminal transition ownership
+
+**File:** `EmojiThrower/GameScene.swift`
+
+Return `Bool` from `presentGameOver`, require both a non-terminal state and
+active `SKView` ownership in one guard, perform terminal mutations only after
+that guard, and present through the validated view reference.
+
+### U2. Portable regression contracts
+
+**File:** `scripts/check-baseline.py`
+
+Parse the presenter body and require the exact ownership predicate, ordering
+before every terminal side effect, validated-view presentation, and accepted
+or rejected return values.
+
+### U3. Maintained evidence
+
+**Files:** `AGENTS.md`, `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`,
+and this plan.
+
+Document active-scene game-over ownership while preserving the existing local
+gameplay, no-network boundary, and historical secret-rotation warning.
+
+## Test Scenarios
+
+- An already terminal scene rejects another game-over transition.
+- A detached scene rejects the transition before terminal state changes.
+- A scene attached to a view but no longer active rejects the transition.
+- The active scene performs terminal shutdown and presents the requested
+  game-over scene exactly once.
+- Existing projectile, collision, spawn, restart, and math contracts remain
+  green.
+
+## Scope Boundaries
+
+- Do not change projectile motion, collision masks, scoring thresholds,
+  spawning cadence, assets, audio, signing, dependencies, or project metadata.
+- Do not retrieve, reproduce, rewrite, or resolve the historical secret alert;
+  owner-side rotation or revocation remains required.
+- Do not add a second test runner or claim local SpriteKit execution on Linux.
+
+## Verification
+
+- Run `make lint`, `make test`, `make build`, and `make check` from the checkout.
+- Run the absolute-path Make gate from an external directory.
+- Parse the checker, validate the Swift runner shell, and run `git diff --check`.
+- Reject isolated mutations for the ownership predicate, guard ordering,
+  validated view use, return contract, guidance, and completed plan evidence.
+- Audit intended files for generated artifacts, protected metadata, and
+  credential-shaped additions.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-18-active-game-over-presentation.md
+++ b/docs/plans/2026-06-18-active-game-over-presentation.md
@@ -1,6 +1,6 @@
 # Active Game-Over Presentation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -87,8 +87,22 @@ gameplay, no-network boundary, and historical secret-rotation warning.
 
 ## Work Completed
 
-Pending implementation.
+- Guarded terminal presentation with active `SKView` scene ownership before
+  every terminal side effect.
+- Returned accepted or rejected transition status and presented through the
+  validated view reference.
+- Added portable ordering, guidance, and completed-evidence contracts without
+  changing gameplay constants or project metadata.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- All four Make gates passed after the completed implementation.
+- The absolute Makefile gate passed from an external directory.
+- `python3 -m py_compile scripts/check-baseline.py` and
+  `sh -n scripts/run-projectile-math-tests.sh` passed.
+- Seven isolated hostile mutations were rejected for ownership, ordering,
+  validated view use, return behavior, guidance, and plan evidence.
+- `git diff --check` passed with generated-artifact, protected-metadata, and
+  changed-line credential audits.
+- Local `swiftc and xcodebuild were unavailable`; hosted macOS remains
+  authoritative for Swift and SpriteKit builds.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation
 SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
+FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -148,6 +149,7 @@ def main():
         "docs/plans/2026-06-10-swift-5-spritekit-build.md",
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
+        "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/readme-overview.svg",
     ]
 
@@ -200,6 +202,7 @@ def main():
     swift_5_build_plan = SWIFT_5_BUILD_PLAN.read_text(encoding="utf-8") if SWIFT_5_BUILD_PLAN.exists() else ""
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
+    finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -286,8 +289,43 @@ def main():
     require("let pointLength = length()" in game_scene and "return CGPoint.zero" in game_scene,
             "CGPoint normalization must handle zero-length vectors",
             failures)
-    require("if (offset.x <= 0) { return }" in game_scene and "let direction = offset.normalized()" in game_scene,
-            "GameScene must guard non-forward projectile vectors before normalization",
+    projectile_direction_index = game_scene.find(
+        "func projectileDirection(offset: CGPoint) -> CGPoint?"
+    )
+    projectile_direction_end = game_scene.find(
+        "func roundSquareImage", projectile_direction_index
+    )
+    projectile_direction_body = game_scene[
+        projectile_direction_index:projectile_direction_end
+    ]
+    touches_ended_index = game_scene.find("override func touchesEnded")
+    touch_direction_guard_index = game_scene.find(
+        "guard let direction = projectileDirection(offset: offset) else",
+        touches_ended_index,
+    )
+    projectile_physics_index = game_scene.find(
+        "projectile.physicsBody =", touches_ended_index
+    )
+    projectile_add_index = game_scene.find("addChild(projectile)", touches_ended_index)
+    projectile_sound_index = game_scene.find(
+        "SKAction.playSoundFileNamed", touches_ended_index
+    )
+    require(projectile_direction_index != -1 and
+            "offset.x.isFinite" in projectile_direction_body and
+            "offset.y.isFinite" in projectile_direction_body and
+            "offset.x > 0" in projectile_direction_body and
+            "offsetLength.isFinite" in projectile_direction_body and
+            "offsetLength > 0" in projectile_direction_body and
+            "direction.x.isFinite" in projectile_direction_body and
+            "direction.y.isFinite" in projectile_direction_body,
+            "GameScene must reject non-finite, non-forward, and overflowed projectile vectors",
+            failures)
+    require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
+            projectile_physics_index != -1 and projectile_add_index != -1 and
+            projectile_sound_index != -1 and
+            touch_direction_guard_index < projectile_physics_index <
+            projectile_add_index < projectile_sound_index,
+            "GameScene must validate projectile direction before physics, insertion, and sound",
             failures)
     require("projectileDidCollideWithMonster(projectile, monster: monster)" in game_scene and
             "monsterDidCollideWithPlayer(monster, player: player)" in game_scene and
@@ -399,6 +437,12 @@ def main():
             "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record the debug cleanup, contact handling, vector guard, image guard, game-over guard, spawn guard, and baseline",
             failures)
+    require("non-finite touch vectors" in readme.lower() and
+            "non-finite touch vectors" in security.lower() and
+            "non-finite touch vectors" in vision.lower() and
+            "non-finite touch vectors" in changes.lower(),
+            "Docs must record finite projectile touch-vector validation",
+            failures)
     require("collision handler" in changes.lower(),
             "CHANGES must record the collision handler game-over guard",
             failures)
@@ -444,6 +488,31 @@ def main():
             "All four Make gates" in undersized_spawn_plan and
             "hostile mutations" in undersized_spawn_plan.lower(),
             "undersized scene spawn plan must record completed status and verification",
+            failures)
+    finite_touch_statuses = re.findall(
+        r"^status: .+$", finite_touch_vector_plan, flags=re.MULTILINE
+    )
+    finite_touch_sections = finite_touch_vector_plan.split(
+        "## Verification Completed\n", 1
+    )
+    finite_touch_verification = (
+        finite_touch_sections[1] if len(finite_touch_sections) == 2 else ""
+    )
+    finite_touch_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "plist, XML, and workflow YAML parsing",
+        "git diff --check",
+        "Seven isolated hostile mutations",
+    )
+    require(finite_touch_statuses == ["status: completed"]
+            and all(item in finite_touch_verification
+                    for item in finite_touch_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          finite_touch_verification,
+                          re.IGNORECASE) is None,
+            "finite projectile touch-vector plan must record completed status and actual local verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,7 @@ CI_PLAN = ROOT / "docs/plans/2026-06-10-ci-baseline.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
+UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -146,6 +147,7 @@ def main():
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-swift-5-spritekit-build.md",
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
+        "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/readme-overview.svg",
     ]
 
@@ -197,6 +199,7 @@ def main():
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     swift_5_build_plan = SWIFT_5_BUILD_PLAN.read_text(encoding="utf-8") if SWIFT_5_BUILD_PLAN.exists() else ""
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
+    undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -235,11 +238,32 @@ def main():
     add_monster_index = game_scene.find("func addMonster()")
     spawn_guard_index = game_scene.find("if gameIsOver { return }", add_monster_index)
     create_enemy_index = game_scene.find("let monster = SKSpriteNode", add_monster_index)
+    spawn_y_index = game_scene.find("func monsterSpawnY(spriteHeight: CGFloat) -> CGFloat?")
+    next_helper_index = game_scene.find("func roundSquareImage", spawn_y_index)
+    spawn_y_body = game_scene[spawn_y_index:next_helper_index]
+    spawn_y_guard_index = game_scene.find(
+        "guard let actualY = monsterSpawnY(spriteHeight: monster.size.height) else",
+        add_monster_index,
+    )
+    add_child_index = game_scene.find("addChild(monster)", add_monster_index)
     require('withKey: "monsterSpawn"' in game_scene and 'removeAction(forKey: "monsterSpawn")' in game_scene,
             "GameScene must run enemy spawning with a key and remove it when game-over presentation starts",
             failures)
     require(add_monster_index != -1 and spawn_guard_index != -1 and spawn_guard_index < create_enemy_index,
             "GameScene must guard enemy spawning after game over before creating sprites",
+            failures)
+    require(spawn_y_index != -1 and next_helper_index != -1 and
+            "guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else" in spawn_y_body and
+            "let minY = spriteHeight / 2" in spawn_y_body and
+            "let maxY = size.height - minY" in spawn_y_body and
+            "guard minY <= maxY else" in spawn_y_body and
+            "return random(min: minY, max: maxY)" in spawn_y_body,
+            "monsterSpawnY must reject invalid geometry before constructing the closed random range",
+            failures)
+    require(spawn_y_guard_index != -1 and add_child_index != -1 and
+            create_enemy_index < spawn_y_guard_index < add_child_index and
+            "random(min: monster.size.height/2" not in game_scene,
+            "addMonster must skip invalid spawn geometry before adding the monster",
             failures)
     require("guard let originalPicture = UIImage(named: imageName)" in game_scene and
             "guard let scaledImage = UIGraphicsGetImageFromCurrentImageContext()" in game_scene and
@@ -346,7 +370,8 @@ def main():
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and
             "background scroll" in readme.lower() and "per-frame" in readme.lower() and "collision handler" in readme.lower() and
-            "contact delegate" in readme.lower() and "restart" in readme.lower() and "GitHub Actions" in readme,
+            "contact delegate" in readme.lower() and "restart" in readme.lower() and
+            "undersized scene" in readme.lower() and "GitHub Actions" in readme,
             "README must document static verification, project usage, SpriteKit context, collision handler guardrails, and image guardrails",
             failures)
     require("local game" in readme.lower() and "debug logging" in readme.lower() and "debug overlays" in readme.lower(),
@@ -355,19 +380,23 @@ def main():
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "asset" in vision.lower() and
             "game-over" in vision.lower() and "spawn" in vision.lower() and
             "background scroll" in vision.lower() and "per-frame" in vision.lower() and "collision handler" in vision.lower() and
-            "contact delegate" in vision.lower() and "restart" in vision.lower() and "GitHub Actions" in vision,
+            "contact delegate" in vision.lower() and "restart" in vision.lower() and
+            "undersized scene" in vision.lower() and "GitHub Actions" in vision,
             "VISION must describe the current static SpriteKit baseline",
             failures)
     require("debug logging" in security.lower() and "debug overlays" in security.lower() and
             "spawn" in security.lower() and "background scroll" in security.lower() and "per-frame" in security.lower() and
             "collision handler" in security.lower() and "contact delegate" in security.lower() and
-            "restart" in security.lower() and "make check" in security and "GitHub Actions" in security,
+            "restart" in security.lower() and "undersized scene" in security.lower() and
+            "make check" in security and "GitHub Actions" in security,
             "SECURITY must document debug logging/overlay and static baseline guardrails",
             failures)
     require("debug console logging" in changes and "debug overlays" in changes and "player-hit" in changes and
             "projectile" in changes and "zero-length" in changes and "image" in changes.lower() and
             "game-over" in changes.lower() and "restart" in changes.lower() and "spawn" in changes.lower() and
-            "background scroll" in changes.lower() and "per-frame" in changes.lower() and "make check" in changes and "make lint" in changes and "make test" in changes and "make build" in changes,
+            "background scroll" in changes.lower() and "per-frame" in changes.lower() and
+            "undersized scene" in changes.lower() and "make check" in changes and
+            "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record the debug cleanup, contact handling, vector guard, image guard, game-over guard, spawn guard, and baseline",
             failures)
     require("collision handler" in changes.lower(),
@@ -410,6 +439,11 @@ def main():
             failures)
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
+            failures)
+    require("status: completed" in undersized_spawn_plan and
+            "All four Make gates" in undersized_spawn_plan and
+            "hostile mutations" in undersized_spawn_plan.lower(),
+            "undersized scene spawn plan must record completed status and verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -61,6 +61,14 @@ def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
 def strip_swift_line_comments(text):
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
 
@@ -403,9 +411,39 @@ def main():
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
             failures)
-    require("status: completed" in duplicate_contact_plan and "mutations" in duplicate_contact_plan.lower(),
-            "duplicate projectile contact plan must record completed mutation verification",
+    duplicate_contact_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan
+    )
+    duplicate_contact_work = markdown_section(duplicate_contact_plan, "Work Completed")
+    duplicate_contact_verification = markdown_section(
+        duplicate_contact_plan, "Verification Completed"
+    )
+    require(duplicate_contact_status == ["completed"] and duplicate_contact_work,
+            "duplicate projectile contact plan must record one completed status and completed work",
             failures)
+    require(duplicate_contact_verification and
+            not re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", duplicate_contact_verification),
+            "duplicate projectile contact plan must record finished verification without pending markers",
+            failures)
+    for evidence in [
+        "make check",
+        "make lint",
+        "make test",
+        "make build",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "git diff --check",
+        "27394998651",
+        "27395002711",
+        "27395075194",
+        "27402323210",
+        "560e645d46cd073f7d062719c486e022e0d79611",
+        "8ce9716ffb4a523612fad6a401a326b2d17b22ac",
+        "guard projectile.parent === self, monster.parent === self else { return }",
+        "monstersDestroyed += 1",
+    ]:
+        require(evidence in duplicate_contact_verification,
+                f"duplicate projectile contact plan must preserve verification evidence: {evidence}",
+                failures)
     workflow_files = sorted(
         str(path.relative_to(ROOT))
         for path in (ROOT / ".github/workflows").rglob("*")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ SWIFT_5_BUILD_PLAN = ROOT / "docs/plans/2026-06-10-swift-5-spritekit-build.md"
 DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md"
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -150,6 +151,7 @@ def main():
         "docs/plans/2026-06-12-projectile-duplicate-contact-guard.md",
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
         "docs/readme-overview.svg",
     ]
 
@@ -203,6 +205,7 @@ def main():
     duplicate_contact_plan = DUPLICATE_CONTACT_PLAN.read_text(encoding="utf-8") if DUPLICATE_CONTACT_PLAN.exists() else ""
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -402,8 +405,12 @@ def main():
     require("*.local.xcconfig" in gitignore and ".env" in gitignore and "DerivedData" in gitignore,
             ".gitignore must exclude local config and Xcode build products",
             failures)
-    require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
-            "Makefile must expose lint, test, and build aliases for the local baseline",
+    require(".PHONY: build check lint test" in makefile and
+            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "lint test build: check" in makefile and
+            'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
+            "python3 scripts/check-baseline.py" not in makefile,
+            "Makefile must expose location-independent lint, test, build, and check aliases",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and
@@ -442,6 +449,10 @@ def main():
             "non-finite touch vectors" in vision.lower() and
             "non-finite touch vectors" in changes.lower(),
             "Docs must record finite projectile touch-vector validation",
+            failures)
+    require("absolute makefile path" in readme.lower() and
+            "location-independent" in changes.lower(),
+            "README and CHANGES must document location-independent Make verification",
             failures)
     require("collision handler" in changes.lower(),
             "CHANGES must record the collision handler game-over guard",
@@ -488,6 +499,24 @@ def main():
             "All four Make gates" in undersized_spawn_plan and
             "hostile mutations" in undersized_spawn_plan.lower(),
             "undersized scene spawn plan must record completed status and verification",
+            failures)
+    location_make_statuses = re.findall(
+        r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE
+    )
+    location_make_verification = markdown_section(
+        location_independent_make_plan, "Verification Completed"
+    )
+    require(location_make_statuses == ["status: completed"] and
+            "All four Make gates passed from the checkout" in location_make_verification and
+            "All four Make gates passed from `/tmp` through the absolute Makefile path" in location_make_verification and
+            "python3 -m py_compile scripts/check-baseline.py" in location_make_verification and
+            "git diff --check" in location_make_verification and
+            "`xcodebuild` was unavailable" in location_make_verification and
+            "Five isolated hostile mutations were rejected" in location_make_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      location_make_verification,
+                      re.IGNORECASE) is None,
+            "location-independent Make plan must record completed status and actual local verification",
             failures)
     finite_touch_statuses = re.findall(
         r"^status: .+$", finite_touch_vector_plan, flags=re.MULTILINE

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import xml.etree.ElementTree as ET
 
 
@@ -772,23 +773,33 @@ def main():
             failures)
 
     if shutil.which("xcodebuild"):
-        result = subprocess.run(
-            [
-                "xcodebuild",
-                "-project", "EmojiThrower.xcodeproj",
-                "-target", "EmojiThrower",
-                "-configuration", "Debug",
-                "-sdk", "iphonesimulator",
-                "CODE_SIGNING_ALLOWED=NO",
-                "build",
-            ],
-            cwd=ROOT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
+        repo_build_existed = (ROOT / "build").exists()
+        with tempfile.TemporaryDirectory(prefix="emoji-xcodebuild-") as build_root:
+            build_root_path = Path(build_root)
+            result = subprocess.run(
+                [
+                    "xcodebuild",
+                    "-project", "EmojiThrower.xcodeproj",
+                    "-scheme", "EmojiThrower",
+                    "-configuration", "Debug",
+                    "-sdk", "iphonesimulator",
+                    "-derivedDataPath", str(build_root_path / "DerivedData"),
+                    f"SYMROOT={build_root_path / 'Products'}",
+                    f"OBJROOT={build_root_path / 'Intermediates'}",
+                    f"SHARED_PRECOMPS_DIR={build_root_path / 'PrecompiledHeaders'}",
+                    "CODE_SIGNING_ALLOWED=NO",
+                    "build",
+                ],
+                cwd=ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
         require(result.returncode == 0,
                 "xcodebuild could not compile EmojiThrower for the simulator: " + result.stdout.strip(),
+                failures)
+        require(repo_build_existed or not (ROOT / "build").exists(),
+                "xcodebuild verification must not leave a repo-local build directory",
                 failures)
     else:
         print("xcodebuild unavailable; static iOS baseline only.")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -28,6 +28,7 @@ UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-gua
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
+PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -118,6 +119,7 @@ def main():
         "EmojiThrower/Info.plist",
         "EmojiThrower/AppDelegate.swift",
         "EmojiThrower/GameScene.swift",
+        "EmojiThrower/ProjectileMath.swift",
         "EmojiThrower/GameViewController.swift",
         "EmojiThrower/GameOverScene.swift",
         "EmojiThrower/GameScene.sks",
@@ -154,7 +156,10 @@ def main():
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-stale-player-contact-guard.md",
+        "docs/plans/2026-06-16-executable-projectile-math-tests.md",
         "docs/readme-overview.svg",
+        "Tests/ProjectileMathTests/main.swift",
+        "scripts/run-projectile-math-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -182,6 +187,9 @@ def main():
     swift_sources = "\n".join(strip_swift_line_comments(path.read_text(encoding="utf-8", errors="replace"))
                               for path in sorted((ROOT / "EmojiThrower").glob("*.swift")))
     game_scene = read("EmojiThrower/GameScene.swift")
+    projectile_math = read("EmojiThrower/ProjectileMath.swift")
+    projectile_tests = read("Tests/ProjectileMathTests/main.swift")
+    projectile_test_runner = read("scripts/run-projectile-math-tests.sh")
     readme = read("README.md")
     vision = read("VISION.md")
     security = read("SECURITY.md")
@@ -209,6 +217,7 @@ def main():
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
+    projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -222,6 +231,10 @@ def main():
             failures)
     for resource in ["Assets.xcassets", "sprites.atlas", "background-music-aac.caf", "pew-pew-lei.caf", "Sketch3D.otf", "GameScene.sks"]:
         require(resource in project, f"Xcode project must keep resource reference: {resource}", failures)
+    require(project.count("ProjectileMath.swift in Sources") == 2 and
+            "path = ProjectileMath.swift;" in project,
+            "Xcode project must compile shared projectile math in the app target",
+            failures)
     require(app_plist.get("UIAppFonts") == ["Sketch3D.otf"],
             "Info.plist must register the bundled Sketch3D font",
             failures)
@@ -317,15 +330,38 @@ def main():
         "SKAction.playSoundFileNamed", touches_ended_index
     )
     require(projectile_direction_index != -1 and
-            "offset.x.isFinite" in projectile_direction_body and
-            "offset.y.isFinite" in projectile_direction_body and
-            "offset.x > 0" in projectile_direction_body and
-            "offsetLength.isFinite" in projectile_direction_body and
-            "offsetLength > 0" in projectile_direction_body and
-            "direction.x.isFinite" in projectile_direction_body and
-            "direction.y.isFinite" in projectile_direction_body,
-            "GameScene must reject non-finite, non-forward, and overflowed projectile vectors",
+            "return ProjectileMath.direction(offset: offset)" in projectile_direction_body,
+            "GameScene must delegate projectile validation to shared executable math",
             failures)
+    for fragment in [
+        "guard offset.x.isFinite, offset.y.isFinite, offset.x > 0",
+        "let offsetLength = sqrt(offset.x * offset.x + offset.y * offset.y)",
+        "guard offsetLength.isFinite, offsetLength > 0",
+        "let direction = CGPoint(x: offset.x / offsetLength, y: offset.y / offsetLength)",
+        "guard direction.x.isFinite, direction.y.isFinite",
+    ]:
+        require(fragment in projectile_math,
+                f"shared projectile math must preserve finite-vector contract: {fragment}",
+                failures)
+    for fragment in [
+        "if !actual.x.isFinite || !actual.y.isFinite",
+        "CGPoint(x: 3.0, y: 4.0)",
+        "CGPoint(x: -1.0, y: 0.0)",
+        "CGPoint(x: .nan, y: 1.0)",
+        "CGFloat.greatestFiniteMagnitude",
+    ]:
+        require(fragment in projectile_tests,
+                f"executable projectile behavior coverage is missing: {fragment}",
+                failures)
+    for fragment in [
+        '"$SWIFTC"',
+        '"$ROOT/EmojiThrower/ProjectileMath.swift"',
+        '"$ROOT/Tests/ProjectileMathTests/main.swift"',
+        '"$BUILD_DIR/projectile-math-tests"',
+    ]:
+        require(fragment in projectile_test_runner,
+                f"projectile behavior test runner is missing: {fragment}",
+                failures)
     require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
             projectile_physics_index != -1 and projectile_add_index != -1 and
             projectile_sound_index != -1 and
@@ -416,11 +452,22 @@ def main():
             ".gitignore must exclude local config and Xcode build products",
             failures)
     require(".PHONY: build check lint test" in makefile and
+            "SWIFTC ?= swiftc" in makefile and
             "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
             "lint test build: check" in makefile and
+            '"$(ROOT)/scripts/run-projectile-math-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
             "python3 scripts/check-baseline.py" not in makefile,
             "Makefile must expose location-independent lint, test, build, and check aliases",
+            failures)
+    require("Status: Completed" in projectile_test_plan and
+            "make check" in projectile_test_plan and
+            "hostile mutations" in projectile_test_plan.lower(),
+            "executable projectile math plan must preserve completed verification evidence",
+            failures)
+    require("docs/plans/2026-06-16-executable-projectile-math-tests.md" in readme and
+            "executable Swift" in readme,
+            "README must document executable projectile math coverage",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -346,6 +346,7 @@ def main():
     for fragment in [
         "if !actual.x.isFinite || !actual.y.isFinite",
         "CGPoint(x: 3.0, y: 4.0)",
+        "CGPoint(x: 0.0, y: 0.0)",
         "CGPoint(x: -1.0, y: 0.0)",
         "CGPoint(x: .nan, y: 1.0)",
         "CGFloat.greatestFiniteMagnitude",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -27,6 +27,7 @@ DUPLICATE_CONTACT_PLAN = ROOT / "docs/plans/2026-06-12-projectile-duplicate-cont
 UNDERSIZED_SPAWN_PLAN = ROOT / "docs/plans/2026-06-13-undersized-scene-spawn-guard.md"
 FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch-vector.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -152,6 +153,7 @@ def main():
         "docs/plans/2026-06-13-undersized-scene-spawn-guard.md",
         "docs/plans/2026-06-13-finite-projectile-touch-vector.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-14-stale-player-contact-guard.md",
         "docs/readme-overview.svg",
     ]
 
@@ -206,6 +208,7 @@ def main():
     undersized_spawn_plan = UNDERSIZED_SPAWN_PLAN.read_text(encoding="utf-8") if UNDERSIZED_SPAWN_PLAN.exists() else ""
     finite_touch_vector_plan = FINITE_TOUCH_VECTOR_PLAN.read_text(encoding="utf-8") if FINITE_TOUCH_VECTOR_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -370,10 +373,17 @@ def main():
             failures)
     player_collision_index = game_scene.find("func monsterDidCollideWithPlayer")
     player_guard_index = game_scene.find("if gameIsOver { return }", player_collision_index)
+    player_active_node_guard_index = game_scene.find("guard monster.parent === self, player.parent === self else { return }", player_collision_index)
     player_destroyed_index = game_scene.find("playerDestroyed = true", player_collision_index)
+    player_remove_index = game_scene.find("player.removeFromParent()", player_collision_index)
     require(player_collision_index != -1 and player_guard_index != -1 and
             player_destroyed_index != -1 and player_guard_index < player_destroyed_index,
             "Player collision handler must ignore late contacts before mutating player state",
+            failures)
+    require(player_active_node_guard_index != -1 and
+            player_guard_index < player_active_node_guard_index < player_destroyed_index and
+            player_active_node_guard_index < player_remove_index,
+            "Player collisions must require active nodes before mutating player state",
             failures)
     game_view_controller = read("EmojiThrower/GameViewController.swift")
     require("guard let skView = view as? SKView" in game_view_controller,
@@ -542,6 +552,23 @@ def main():
                           finite_touch_verification,
                           re.IGNORECASE) is None,
             "finite projectile touch-vector plan must record completed status and actual local verification",
+            failures)
+    stale_player_contact_statuses = re.findall(
+        r"^status: .+$", stale_player_contact_plan, flags=re.MULTILINE
+    )
+    stale_player_contact_verification = markdown_section(
+        stale_player_contact_plan, "Verification Completed"
+    )
+    require(stale_player_contact_statuses == ["status: completed"] and
+            "All four Make gates" in stale_player_contact_verification and
+            "absolute Makefile path" in stale_player_contact_verification and
+            "Five isolated hostile mutations" in stale_player_contact_verification and
+            "git diff --check" in stale_player_contact_verification and
+            "`xcodebuild` was unavailable" in stale_player_contact_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      stale_player_contact_verification,
+                      re.IGNORECASE) is None,
+            "stale player contact plan must record completed status and actual local verification",
             failures)
     duplicate_contact_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", duplicate_contact_plan

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -29,6 +29,7 @@ FINITE_TOUCH_VECTOR_PLAN = ROOT / "docs/plans/2026-06-13-finite-projectile-touch
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
 PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
+SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -157,6 +158,7 @@ def main():
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-stale-player-contact-guard.md",
         "docs/plans/2026-06-16-executable-projectile-math-tests.md",
+        "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md",
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
@@ -218,6 +220,7 @@ def main():
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
     projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
+    scene_aware_distance_plan = SCENE_AWARE_DISTANCE_PLAN.read_text(encoding="utf-8") if SCENE_AWARE_DISTANCE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -329,6 +332,10 @@ def main():
     projectile_sound_index = game_scene.find(
         "SKAction.playSoundFileNamed", touches_ended_index
     )
+    projectile_distance_guard_index = game_scene.find(
+        "guard let projectileTravelDistance = ProjectileMath.exitDistance(",
+        touches_ended_index,
+    )
     require(projectile_direction_index != -1 and
             "return ProjectileMath.direction(offset: offset)" in projectile_direction_body,
             "GameScene must delegate projectile validation to shared executable math",
@@ -344,6 +351,20 @@ def main():
                 f"shared projectile math must preserve finite-vector contract: {fragment}",
                 failures)
     for fragment in [
+        "static func exitDistance(sceneSize: CGSize, projectileSize: CGSize) -> CGFloat?",
+        "sceneSize.width.isFinite, sceneSize.height.isFinite",
+        "sceneSize.width > 0, sceneSize.height > 0",
+        "projectileSize.width.isFinite, projectileSize.height.isFinite",
+        "projectileSize.width >= 0, projectileSize.height >= 0",
+        "let sceneDiagonal = hypot(sceneSize.width, sceneSize.height)",
+        "let projectileClearance = max(projectileSize.width, projectileSize.height)",
+        "let distance = sceneDiagonal + projectileClearance",
+        "guard sceneDiagonal.isFinite, distance.isFinite, distance > 0",
+    ]:
+        require(fragment in projectile_math,
+                f"shared projectile math must preserve scene-aware exit distance: {fragment}",
+                failures)
+    for fragment in [
         "if !actual.x.isFinite || !actual.y.isFinite",
         "CGPoint(x: 3.0, y: 4.0)",
         "CGPoint(x: 0.0, y: 0.0)",
@@ -355,6 +376,21 @@ def main():
                 f"executable projectile behavior coverage is missing: {fragment}",
                 failures)
     for fragment in [
+        "ProjectileMath.exitDistance(",
+        "CGSize(width: 1366.0, height: 1024.0)",
+        "CGSize(width: 768.0, height: 1366.0)",
+        "hypot(1366.0, 1024.0) + 40.0",
+        "zero-width scenes are rejected",
+        "negative scene dimensions are rejected",
+        "non-finite scene dimensions are rejected",
+        "negative projectile dimensions are rejected",
+        "non-finite projectile dimensions are rejected",
+        "overflowing exit distances are rejected",
+    ]:
+        require(fragment in projectile_tests,
+                f"executable projectile exit-distance coverage is missing: {fragment}",
+                failures)
+    for fragment in [
         '"$SWIFTC"',
         '"$ROOT/EmojiThrower/ProjectileMath.swift"',
         '"$ROOT/Tests/ProjectileMathTests/main.swift"',
@@ -364,11 +400,17 @@ def main():
                 f"projectile behavior test runner is missing: {fragment}",
                 failures)
     require(touches_ended_index != -1 and touch_direction_guard_index != -1 and
+            projectile_distance_guard_index != -1 and
             projectile_physics_index != -1 and projectile_add_index != -1 and
             projectile_sound_index != -1 and
-            touch_direction_guard_index < projectile_physics_index <
+            touch_direction_guard_index < projectile_distance_guard_index <
+            projectile_physics_index <
             projectile_add_index < projectile_sound_index,
-            "GameScene must validate projectile direction before physics, insertion, and sound",
+            "GameScene must validate projectile direction and exit geometry before physics, insertion, and sound",
+            failures)
+    require("let shootDistance = direction * projectileTravelDistance" in game_scene and
+            "direction * 1000" not in game_scene,
+            "GameScene must use scene-aware projectile travel distance instead of a fixed scalar",
             failures)
     require("projectileDidCollideWithMonster(projectile, monster: monster)" in game_scene and
             "monsterDidCollideWithPlayer(monster, player: player)" in game_scene and
@@ -469,6 +511,18 @@ def main():
     require("docs/plans/2026-06-16-executable-projectile-math-tests.md" in readme and
             "executable Swift" in readme,
             "README must document executable projectile math coverage",
+            failures)
+    require("title: Scene-Aware Projectile Exit Distance" in scene_aware_distance_plan and
+            "type: fix" in scene_aware_distance_plan and
+            "date: 2026-06-17" in scene_aware_distance_plan and
+            "R1." in scene_aware_distance_plan and "R6." in scene_aware_distance_plan and
+            "status:" not in scene_aware_distance_plan.lower(),
+            "scene-aware projectile distance plan must preserve portable metadata and requirements",
+            failures)
+    require("scene-aware exit distance" in readme.lower() and
+            "2026-06-17-020-fix-scene-aware-projectile-distance-plan.md" in readme and
+            "scene-aware" in changes.lower() and "projectile travel" in changes.lower(),
+            "README and CHANGES must document scene-aware projectile travel",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -30,6 +30,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independ
 STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-guard.md"
 PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
 SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md"
+ACTIVE_GAME_OVER_PLAN = ROOT / "docs/plans/2026-06-18-active-game-over-presentation.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -221,6 +222,7 @@ def main():
     stale_player_contact_plan = STALE_PLAYER_CONTACT_PLAN.read_text(encoding="utf-8") if STALE_PLAYER_CONTACT_PLAN.exists() else ""
     projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
     scene_aware_distance_plan = SCENE_AWARE_DISTANCE_PLAN.read_text(encoding="utf-8") if SCENE_AWARE_DISTANCE_PLAN.exists() else ""
+    active_game_over_plan = ACTIVE_GAME_OVER_PLAN.read_text(encoding="utf-8") if ACTIVE_GAME_OVER_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -418,12 +420,30 @@ def main():
             "GameScene must guard physics contact casts and handle projectile/player contacts",
             failures)
     require("var gameIsOver = false" in game_scene and
-            "func presentGameOver(won: Bool, transition: SKTransition)" in game_scene and
-            "if gameIsOver { return }" in game_scene and
+            "func presentGameOver(won: Bool, transition: SKTransition) -> Bool" in game_scene and
             "gameIsOver = true" in game_scene,
             "GameScene must guard repeated game-over transition handling",
             failures)
     present_game_over_index = game_scene.find("func presentGameOver")
+    projectile_collision_index = game_scene.find("func projectileDidCollideWithMonster")
+    present_game_over_body = game_scene[present_game_over_index:projectile_collision_index]
+    ownership_guard = "guard !gameIsOver, let view = self.view, view.scene === self else {"
+    ownership_guard_index = present_game_over_body.find(ownership_guard)
+    terminal_side_effect_indexes = [
+        present_game_over_body.find("gameIsOver = true"),
+        present_game_over_body.find('removeAction(forKey: "monsterSpawn")'),
+        present_game_over_body.find("physicsWorld.contactDelegate = nil"),
+        present_game_over_body.find("let gameOverScene = GameOverScene"),
+        present_game_over_body.find("view.presentScene(gameOverScene, transition: transition)"),
+    ]
+    require("@discardableResult" in game_scene[max(0, present_game_over_index - 30):present_game_over_index] and
+            ownership_guard_index != -1 and
+            "return false" in present_game_over_body and
+            "return true" in present_game_over_body and
+            all(index > ownership_guard_index for index in terminal_side_effect_indexes) and
+            "self.view?.presentScene" not in present_game_over_body,
+            "game-over terminal side effects must require active-scene view ownership",
+            failures)
     contact_delegate_clear_index = game_scene.find("physicsWorld.contactDelegate = nil", present_game_over_index)
     present_scene_index = game_scene.find("presentScene", present_game_over_index)
     require("physicsWorld.contactDelegate = self" in game_scene and
@@ -435,7 +455,6 @@ def main():
             "presentGameOver(won: false, transition: reveal)" in game_scene,
             "GameScene win and loss paths must use the guarded game-over presenter",
             failures)
-    projectile_collision_index = game_scene.find("func projectileDidCollideWithMonster")
     projectile_guard_index = game_scene.find("if gameIsOver { return }", projectile_collision_index)
     projectile_active_node_guard_index = game_scene.find("guard projectile.parent === self, monster.parent === self else { return }", projectile_collision_index)
     projectile_remove_index = game_scene.find("projectile.removeFromParent()", projectile_collision_index)
@@ -523,6 +542,36 @@ def main():
             "2026-06-17-020-fix-scene-aware-projectile-distance-plan.md" in readme and
             "scene-aware" in changes.lower() and "projectile travel" in changes.lower(),
             "README and CHANGES must document scene-aware projectile travel",
+            failures)
+    active_game_over_statuses = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", active_game_over_plan
+    )
+    active_game_over_verification = markdown_section(
+        active_game_over_plan, "Verification Completed"
+    )
+    active_game_over_required = (
+        "All four Make gates",
+        "absolute Makefile",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n scripts/run-projectile-math-tests.sh",
+        "Seven isolated hostile mutations",
+        "git diff --check",
+        "swiftc and xcodebuild were unavailable",
+    )
+    require(active_game_over_statuses == ["completed"] and
+            all(item in active_game_over_verification
+                for item in active_game_over_required) and
+            not re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b",
+                          active_game_over_verification),
+            "active game-over plan must record completed verification",
+            failures)
+    normalized_guidance = [
+        " ".join(document.lower().split())
+        for document in [readme, security, vision, changes, agent_guidance]
+    ]
+    require(all("active-scene game-over ownership" in document
+                for document in normalized_guidance),
+            "project guidance must document active-scene game-over ownership",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and

--- a/scripts/run-projectile-math-tests.sh
+++ b/scripts/run-projectile-math-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/emoji-projectile-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/EmojiThrower/ProjectileMath.swift" \
+    "$ROOT/Tests/ProjectileMathTests/main.swift" \
+    -o "$BUILD_DIR/projectile-math-tests"
+
+"$BUILD_DIR/projectile-math-tests"


### PR DESCRIPTION
## Summary
Require authoritative SpriteKit view ownership before a GameScene enters terminal game-over state or presents its destination.

## Baseline
presentGameOver marked the scene terminal, cancelled spawning, and cleared contact delivery before optionally presenting through self.view, so a late callback on a detached scene could stop gameplay without presenting the game-over scene.

## Improvements
- Require a non-terminal GameScene that is still the active SKView scene.
- Validate ownership before terminal state, spawn cancellation, contact-delegate cleanup, destination creation, or presentation.
- Return whether the transition was accepted and present through the validated view reference.
- Add mutation-sensitive portable contracts and completed plan evidence.

## Validation
- make check
- make lint
- make build
- make test (portable baseline passed; swiftc and xcodebuild are unavailable locally)
- Absolute Makefile check from an external directory
- python3 -m py_compile scripts/check-baseline.py
- sh -n scripts/run-projectile-math-tests.sh
- Seven isolated hostile mutations rejected
- git diff --check, artifact audit, protected-metadata audit, conflict-marker audit, and changed-line credential scan
- Exact head `de6a532fb373b29fa13d453bac4af38e16fff3e5` passed push run `27741497441` and pull-request run `27741504519`.

## Risk
Low. The change narrows transition acceptance without changing scoring, collision masks, projectile behavior, scene dimensions, assets, audio, dependencies, or project metadata. Historical secret-scanning alert #1 remains open and is not reproduced or modified by this change.

## Post-Deploy Monitoring & Validation
The hosted macOS push and pull-request jobs compiled the exact head successfully. The repository owner must separately verify revocation or rotation before resolving historical secret alert #1.

## Follow-Ups
- Verify owner-side revocation or rotation and resolve historical secret-scanning alert #1 without exposing the credential or rewriting history here.
