### PR TITLE
Protect Make root from command-line overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build check lint test
 
 SWIFTC ?= swiftc
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -516,7 +516,7 @@ def main():
             failures)
     require(".PHONY: build check lint test" in makefile and
             "SWIFTC ?= swiftc" in makefile and
-            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
             "lint test build: check" in makefile and
             '"$(ROOT)/scripts/run-projectile-math-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and


### PR DESCRIPTION
## Summary

Protect the Makefile's repository root from command-line variable overrides.

## Baseline

The existing `ROOT := ...` assignment could be replaced with `make ROOT=...`, redirecting both the projectile-math harness and baseline checker outside the checkout.

## Improvements

- Use `override ROOT := ...` so every Make alias stays bound to the Makefile directory.
- Update the baseline assertion to require the protected assignment.

## Validation

- `make check`, `make lint`, `make test`, and `make build` from the repository root with hostile `ROOT` values
- The same four aliases through the absolute Makefile path from an external directory
- Downgrade mutation rejected by `make check`
- In-memory Python compilation and shell syntax validation
- `git diff --check` and `git fsck --no-dangling`
- Checksum-verified Gitleaks 8.30.1 history and current-tree scans reported no findings
- Current master has no tracked credential-shaped matches

Local Swift and Xcode execution are unavailable, so hosted macOS remains the authoritative executable and project-build gate.

## Risk

Low for this change. It affects only Make variable precedence and the baseline assertion that enforces it; gameplay behavior is unchanged.

GitHub secret scanning separately retains one open historical Google API key alert from a 2016 commit. The referenced plist is absent from current master, and this PR does not expose, modify, or claim revocation of that historical value.

## Follow-Ups

Confirm the exact PR head passes hosted Check and CodeQL workflows before merge. Resolve the historical secret-scanning alert only after independently verifying revocation or an appropriate repository-owner disposition.
