### PR TITLE
Keep emoji layout aligned on scene resize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ player launches emoji projectiles at moving targets.
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.
 - Keep active-scene game-over ownership ahead of terminal state, spawn,
   contact-delegate, and presentation side effects.
+- Keep persistent player and score positions derived from `SKScene.size`, and
+  reapply them from `didChangeSize(_:)` when `.resizeFill` resizes the scene.
 - This is an Apple platform sample. Xcode, Swift, and deployment target versions
   must stay aligned with the checked-in project settings.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 2026-06-25 06:22 PDT
+
+- Centralized persistent player and score positioning on `SKScene.size` and
+  reapplied it from `didChangeSize(_:)`, keeping both nodes correctly placed
+  when `.resizeFill` updates the scene during iPad rotation or view resizing.
+- Added a comment-aware static regression contract, a runtime rotation check,
+  and a completed implementation plan without changing gameplay constants,
+  assets, project metadata, or the local-only data boundary.
+
 ## 2026-06-18
 
 - Required active-scene game-over ownership before terminal state changes,

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -71,8 +71,6 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         let backgroundMusic = SKAudioNode(fileNamed: "background-music-aac.caf")
         backgroundMusic.autoplayLooped = true
         addChild(backgroundMusic)
-        // set starting position
-        player.position = CGPoint(x: size.width * 0.1, y: size.height * 0.5)
         // create sprite
         addChild(player)
         // add physics to player
@@ -92,10 +90,20 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
                 ])
             ), withKey: "monsterSpawn")
         scoreLabel.fontSize = 50
-        scoreLabel.position = CGPoint(x: view.frame.width/2, y: view.frame.height-40)
         scoreLabel.fontColor = #colorLiteral(red: 0.137254902, green: 0.137254902, blue: 0.3450980392, alpha: 1)
         scoreLabel.text = "Score: 0"
         addChild(scoreLabel)
+        layoutPersistentNodes()
+    }
+
+    func layoutPersistentNodes() {
+        player.position = CGPoint(x: size.width * 0.1, y: size.height * 0.5)
+        scoreLabel.position = CGPoint(x: size.width * 0.5, y: size.height - 40)
+    }
+
+    override func didChangeSize(_ oldSize: CGSize) {
+        super.didChangeSize(oldSize)
+        layoutPersistentNodes()
     }
     //MARK: - Create a random number
     func random(min: CGFloat, max: CGFloat) -> CGFloat {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ unsigned simulator build when Xcode is available.
   position until game over.
 - Projectile launches use a scene-aware exit distance so the whole node clears
   wide and tall scene bounds before its movement action completes.
+- Persistent player and score layout derives from the current scene size and is
+  reapplied when `.resizeFill` changes that size, including iPad rotation.
 - This is a local game sample. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
@@ -96,7 +98,8 @@ checks Xcode resource references, verifies the Swift source inventory, and
 guards against image-helper force unwraps, non-finite touch vectors, repeated
 game-over transitions, unguarded game-over restarts, stale collision nodes,
 late collision handler mutations, uncleared contact delegate callbacks, late
-spawn actions, broken per-frame background scroll movement, debug logging,
+spawn actions, stale persistent-node resize layout, broken per-frame background
+scroll movement, debug logging,
 network, analytics, upload, or persistence behavior.
 The executable harness covers both finite direction normalization and
 scene-aware projectile travel for wide, tall, invalid, and overflowing geometry.
@@ -107,8 +110,10 @@ the baseline also compiles an unsigned Swift 5 Debug app build for the iOS
 Simulator. The repository has no XCTest target, and the hosted boundary does not
 launch SpriteKit gameplay, render frames, play audio, or run physics simulation.
 
-For runtime verification on macOS, launch the game in a simulator and exercise
-projectiles, collisions, game-over transitions, and restart behavior.
+For runtime verification on macOS, launch the game in an iPad simulator,
+exercise projectiles, collisions, game-over transitions, and restart behavior,
+then rotate between portrait and landscape and confirm the player remains at
+the left-center gameplay position while the score remains centered at the top.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 
@@ -151,6 +156,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   projectile validation and executable Swift behavioral gate.
 - See `docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md`
   for the scene-aware exit distance and invalid-geometry guardrail.
+- See `docs/plans/2026-06-25-resize-safe-persistent-layout.md` for the
+  scene-size-driven player and score layout guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
-- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
+- `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, scene-size-driven player and score layout, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - Active-scene game-over ownership prevents detached scenes from mutating
   terminal gameplay state without an authoritative presentation target.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions

--- a/VISION.md
+++ b/VISION.md
@@ -18,6 +18,8 @@ Priority:
 
 - Preserve the core SpriteKit gameplay loop
 - Keep scene, score, and game-over behavior easy to inspect
+- Keep persistent player and score positions tied to the current scene size
+  when `.resizeFill` responds to view or orientation changes
 - Maintain asset and sound file alignment with project references
 - Keep optional image helper rendering tolerant of missing assets
 - Keep game-over transitions guarded against repeated contact handling

--- a/docs/plans/2026-06-25-resize-safe-persistent-layout.md
+++ b/docs/plans/2026-06-25-resize-safe-persistent-layout.md
@@ -1,0 +1,116 @@
+# Resize-Safe Persistent Layout
+
+status: completed
+
+## Context
+
+The game presents `GameScene` with SpriteKit's `.resizeFill` scale mode and the
+iPad metadata supports every interface orientation. SpriteKit therefore changes
+the scene size when the presenting view changes size. The player and score were
+positioned only during `didMove(to:)`, leaving both nodes at stale coordinates
+after an iPad rotation or another view-size change.
+
+Apple documents `didChangeSize(_:)` as the scene callback for adjusting node
+positions after a size change, and documents `.resizeFill` as keeping scene and
+view dimensions matched.
+
+## Priority
+
+Keep persistent gameplay controls and feedback inside the current visible scene
+without changing projectile, collision, scoring, spawn, or transition behavior.
+
+## Requirements
+
+- R1. Initial player and score positions must derive from `SKScene.size`, not
+  the presenting view's frame.
+- R2. One layout helper must own both persistent-node positions.
+- R3. `didMove(to:)` must apply that helper for initial presentation.
+- R4. `didChangeSize(_:)` must call `super` and reapply that helper.
+- R5. The player remains at 10 percent of scene width and half scene height.
+- R6. The score remains horizontally centered and 40 points below the scene's
+  top edge.
+- R7. Portable contracts must reject missing, commented-out, weakened, or
+  view-frame-based layout behavior.
+
+## Implementation Units
+
+### U1. Centralize persistent-node layout
+
+**File:** `EmojiThrower/GameScene.swift`
+
+Move player and score positioning into `layoutPersistentNodes()`, invoke it
+after initial node setup, and invoke it from `didChangeSize(_:)`.
+
+### U2. Portable regression contract
+
+**File:** `scripts/check-baseline.py`
+
+Strip block and line comments for this contract, then verify initial and resize
+callbacks, exact scene-relative coordinates, and removal of view-frame layout.
+
+### U3. Maintained evidence
+
+**Files:** `AGENTS.md`, `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`,
+and this plan.
+
+Document the resize-safe layout invariant, runtime rotation check, verification
+boundary, and timestamped change evidence.
+
+## Test Scenarios
+
+- Initial presentation places the player and score from the scene size.
+- A scene resize re-centers the score against the new width and top edge.
+- A scene resize moves the player to the same relative gameplay position.
+- Commenting out either layout callback or coordinate assignment fails the
+  portable baseline.
+- Reintroducing `view.frame` layout fails the portable baseline.
+
+## Scope Boundaries
+
+- Do not change gameplay constants, score values, collision masks, spawn
+  cadence, projectile motion, assets, audio, signing, or project metadata.
+- Do not reposition in-flight projectiles or monsters during a resize.
+- Do not add dependencies or a second test runner.
+- Do not claim local SpriteKit runtime execution when Xcode is unavailable.
+
+## Primary Sources
+
+- Apple, `SKScene.didChangeSize(_:)`:
+  https://developer.apple.com/documentation/spritekit/skscene/didchangesize%28_%3A%29
+- Apple, `SKSceneScaleMode.resizeFill`:
+  https://developer.apple.com/documentation/spritekit/skscenescalemode/resizefill
+- Apple, `SKScene.size`:
+  https://developer.apple.com/documentation/spritekit/skscene/size
+
+## Verification
+
+- Run `make lint`, `make test`, `make build`, and `make check`.
+- Run the absolute-path Make gate from an external directory.
+- Parse the checker and validate the Swift runner shell.
+- Reject isolated hostile mutations for each callback, coordinate assignment,
+  comment suppression, and view-frame regression.
+- Run `git diff --check` and audit intended files for generated artifacts,
+  protected metadata, and credential-shaped additions.
+
+## Work Completed
+
+- Centralized player and score positioning in `layoutPersistentNodes()`.
+- Applied the shared layout during initial presentation and every scene-size
+  change.
+- Added a comment-aware portable contract and maintained documentation without
+  changing gameplay constants or project metadata.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- The absolute Makefile `check` gate passed from `/tmp`.
+- `python3 -m py_compile scripts/check-baseline.py`,
+  `sh -n scripts/run-projectile-math-tests.sh`, and `git diff --check` passed.
+- Eight isolated hostile mutations were rejected for the initial layout call,
+  resize override, superclass callback, player coordinate, score coordinate,
+  line-comment suppression, block-comment suppression, and view-frame
+  regression.
+- Generated-artifact, protected-metadata, and changed-line credential audits
+  found no unintended additions.
+- Local `swiftc` and `xcodebuild` were unavailable; hosted macOS remains
+  authoritative for executable Swift tests and the unsigned simulator build.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -32,6 +32,7 @@ STALE_PLAYER_CONTACT_PLAN = ROOT / "docs/plans/2026-06-14-stale-player-contact-g
 PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-tests.md"
 SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md"
 ACTIVE_GAME_OVER_PLAN = ROOT / "docs/plans/2026-06-18-active-game-over-presentation.md"
+RESIZE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-25-resize-safe-persistent-layout.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -79,6 +80,10 @@ def markdown_section(text, heading):
 
 def strip_swift_line_comments(text):
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
+
+
+def strip_swift_comments(text):
+    return strip_swift_line_comments(re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL))
 
 
 def parse_xml(relative_path, failures):
@@ -161,6 +166,7 @@ def main():
         "docs/plans/2026-06-14-stale-player-contact-guard.md",
         "docs/plans/2026-06-16-executable-projectile-math-tests.md",
         "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md",
+        "docs/plans/2026-06-25-resize-safe-persistent-layout.md",
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
@@ -224,6 +230,7 @@ def main():
     projectile_test_plan = PROJECTILE_TEST_PLAN.read_text(encoding="utf-8") if PROJECTILE_TEST_PLAN.exists() else ""
     scene_aware_distance_plan = SCENE_AWARE_DISTANCE_PLAN.read_text(encoding="utf-8") if SCENE_AWARE_DISTANCE_PLAN.exists() else ""
     active_game_over_plan = ACTIVE_GAME_OVER_PLAN.read_text(encoding="utf-8") if ACTIVE_GAME_OVER_PLAN.exists() else ""
+    resize_layout_plan = RESIZE_LAYOUT_PLAN.read_text(encoding="utf-8") if RESIZE_LAYOUT_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -254,8 +261,23 @@ def main():
     require('scoreLabel.text = "Score: \\(monstersDestroyed)"' in game_scene,
             "GameScene must keep visible score label updates",
             failures)
-    require('scoreLabel.text = "Score: 0"' in game_scene and "view.frame.width/2" in game_scene,
-            "GameScene must initialize visible score text without force-unwrapping self.view",
+    game_scene_contracts = strip_swift_comments(game_scene)
+    did_move_index = game_scene_contracts.find("override func didMove(to view: SKView)")
+    layout_call_index = game_scene_contracts.find("layoutPersistentNodes()", did_move_index)
+    layout_index = game_scene_contracts.find("func layoutPersistentNodes()")
+    did_change_size_index = game_scene_contracts.find("override func didChangeSize(_ oldSize: CGSize)")
+    contract_add_monster_index = game_scene_contracts.find("func addMonster()")
+    layout_body = game_scene_contracts[layout_index:did_change_size_index]
+    resize_body = game_scene_contracts[did_change_size_index:contract_add_monster_index]
+    require('scoreLabel.text = "Score: 0"' in game_scene and
+            did_move_index != -1 and did_move_index < layout_call_index < layout_index and
+            "player.position = CGPoint(x: size.width * 0.1, y: size.height * 0.5)" in layout_body and
+            "scoreLabel.position = CGPoint(x: size.width * 0.5, y: size.height - 40)" in layout_body and
+            "super.didChangeSize(oldSize)" in resize_body and
+            "layoutPersistentNodes()" in resize_body and
+            "view.frame.width" not in game_scene_contracts and
+            "view.frame.height" not in game_scene_contracts,
+            "GameScene must relayout the player and score from scene size changes",
             failures)
     require("SKAction.playSoundFileNamed" in game_scene and "background-music-aac.caf" in game_scene,
             "GameScene must keep bundled sound playback references",
@@ -612,6 +634,14 @@ def main():
             "non-finite touch vectors" in changes.lower(),
             "Docs must record finite projectile touch-vector validation",
             failures)
+    require("Persistent player and score layout" in readme and
+            "didChangeSize(_:)" in agent_guidance and
+            "persistent player and score positions" in vision.lower() and
+            "scene-size-driven player and score layout" in security.lower() and
+            "2026-06-25 06:22 PDT" in changes and
+            "didChangeSize(_:)" in changes,
+            "Docs must record resize-safe persistent player and score layout",
+            failures)
     require("absolute makefile path" in readme.lower() and
             "location-independent" in changes.lower(),
             "README and CHANGES must document location-independent Make verification",
@@ -656,6 +686,27 @@ def main():
             failures)
     require("status: completed" in swift_5_build_plan and "simulator" in swift_5_build_plan.lower(),
             "Swift 5 SpriteKit build plan must be completed and document simulator verification",
+            failures)
+    resize_layout_statuses = re.findall(
+        r"^status: .+$", resize_layout_plan, flags=re.MULTILINE
+    )
+    resize_layout_verification = markdown_section(
+        resize_layout_plan, "Verification Completed"
+    )
+    resize_layout_evidence = [
+        "All four Make gates passed from the checkout",
+        "absolute Makefile `check` gate passed from `/tmp`",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n scripts/run-projectile-math-tests.sh",
+        "git diff --check",
+        "Eight isolated hostile mutations were rejected",
+        "Local `swiftc` and `xcodebuild` were unavailable",
+    ]
+    require(resize_layout_statuses == ["status: completed"] and
+            all(item in resize_layout_verification for item in resize_layout_evidence) and
+            re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b",
+                      resize_layout_verification) is None,
+            "resize-safe persistent layout plan must record completed local verification",
             failures)
     require("status: completed" in undersized_spawn_plan and
             "All four Make gates" in undersized_spawn_plan and


### PR DESCRIPTION
## Summary
- centralize player and score positioning on `SKScene.size`
- reapply persistent-node layout from `didChangeSize(_:)` for `.resizeFill` changes
- add comment-aware regression contracts, timestamped change evidence, and maintenance guidance

## Verification
- `make lint`
- `make test`
- `make build`
- `make check`
- absolute-path `make check` from `/tmp`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n scripts/run-projectile-math-tests.sh`
- eight isolated hostile mutations
- `git diff --check`

Local `swiftc` and `xcodebuild` were unavailable; the hosted macOS workflow remains authoritative for executable Swift tests and the unsigned simulator build.

## Primary sources
- https://developer.apple.com/documentation/spritekit/skscene/didchangesize%28_%3A%29
- https://developer.apple.com/documentation/spritekit/skscenescalemode/resizefill
- https://developer.apple.com/documentation/spritekit/skscene/size
