### PR TITLE
Keep scrolling backgrounds contiguous after resize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ player launches emoji projectiles at moving targets.
   contact-delegate, and presentation side effects.
 - Keep persistent player and score positions derived from `SKScene.size`, and
   reapply them from `didChangeSize(_:)` when `.resizeFill` resizes the scene.
+- Keep the two scrolling background tiles contiguous after initial setup and
+  every scene-size change without resizing them independently per frame.
 - This is an Apple platform sample. Xcode, Swift, and deployment target versions
   must stay aligned with the checked-in project settings.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 2026-06-26
+
+- Centralized scrolling background sizing and adjacency on `SKScene.size`.
+- Preserved the leading tile's scroll phase while retiling both backgrounds
+  during initial setup and every `.resizeFill` size change.
+- Removed independent per-frame background resizing, which could introduce gaps
+  or overlap after rotation.
+- Added a red-first, comment-aware static contract and completed verification
+  plan without changing scroll speed, gameplay nodes, scoring, or collisions.
+
 ## 2026-06-25 06:22 PDT
 
 - Centralized persistent player and score positioning on `SKScene.size` and

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -101,9 +101,38 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         scoreLabel.position = CGPoint(x: size.width * 0.5, y: size.height - 40)
     }
 
+    func layoutScrollingBackground() {
+        let backgrounds = children.compactMap { child -> SKSpriteNode? in
+            guard child.name == "background" else { return nil }
+            return child as? SKSpriteNode
+        }.sorted { $0.position.x < $1.position.x }
+        guard backgrounds.count == 2,
+            size.width.isFinite, size.height.isFinite,
+            size.width > 0, size.height > 0,
+            backgrounds.allSatisfy({ $0.position.x.isFinite }) else {
+                return
+        }
+
+        var leadingX = backgrounds[0].position.x.truncatingRemainder(
+            dividingBy: size.width
+        )
+        if leadingX > 0 {
+            leadingX -= size.width
+        }
+
+        for (index, background) in backgrounds.enumerated() {
+            background.size = size
+            background.position = CGPoint(
+                x: leadingX + CGFloat(index) * size.width,
+                y: 0
+            )
+        }
+    }
+
     override func didChangeSize(_ oldSize: CGSize) {
         super.didChangeSize(oldSize)
         layoutPersistentNodes()
+        layoutScrollingBackground()
     }
     //MARK: - Create a random number
     func random(min: CGFloat, max: CGFloat) -> CGFloat {
@@ -207,13 +236,13 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             bg.name = "background"
             self.addChild(bg)
         }
+        layoutScrollingBackground()
     }
     
     //
     func moveBackground() {
         self.enumerateChildNodes(withName: "background", using: { (node, stop) -> Void in
             if let bg = node as? SKSpriteNode {
-                bg.size = self.frame.size
                 bg.position = CGPoint(x: bg.position.x - self.backgroundVelocity, y: bg.position.y)
                 bg.zPosition = -13
                 // Checks if bg node is completely scrolled off the screen, if yes, then puts it at the end of the other node.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ unsigned simulator build when Xcode is available.
 - Enemy spawning is keyed and stopped when game-over presentation starts.
 - Background scroll movement advances per-frame from each node's current
   position until game over.
+- Resize-safe background tiling preserves both tiles' scroll phase and retiles
+  them contiguously from `SKScene.size` after `.resizeFill` size changes.
 - Projectile launches use a scene-aware exit distance so the whole node clears
   wide and tall scene bounds before its movement action completes.
 - Persistent player and score layout derives from the current scene size and is
@@ -98,8 +100,8 @@ checks Xcode resource references, verifies the Swift source inventory, and
 guards against image-helper force unwraps, non-finite touch vectors, repeated
 game-over transitions, unguarded game-over restarts, stale collision nodes,
 late collision handler mutations, uncleared contact delegate callbacks, late
-spawn actions, stale persistent-node resize layout, broken per-frame background
-scroll movement, debug logging,
+spawn actions, stale persistent-node or background resize layout, broken
+per-frame background scroll movement, debug logging,
 network, analytics, upload, or persistence behavior.
 The executable harness covers both finite direction normalization and
 scene-aware projectile travel for wide, tall, invalid, and overflowing geometry.
@@ -158,6 +160,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   for the scene-aware exit distance and invalid-geometry guardrail.
 - See `docs/plans/2026-06-25-resize-safe-persistent-layout.md` for the
   scene-size-driven player and score layout guardrail.
+- See `docs/plans/2026-06-26-resize-safe-background-tiling.md` for contiguous
+  scrolling background layout across scene-size changes.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/VISION.md
+++ b/VISION.md
@@ -33,6 +33,7 @@ Priority:
   the monster sprite
 - Reject non-finite touch vectors before projectile side effects
 - Keep background scroll movement running per-frame until game over
+- Keep both scrolling background tiles contiguous when the scene size changes
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode
   metadata, SpriteKit source inventory, local-only gameplay, contact handling,

--- a/docs/plans/2026-06-26-resize-safe-background-tiling.md
+++ b/docs/plans/2026-06-26-resize-safe-background-tiling.md
@@ -1,0 +1,56 @@
+# Resize-Safe Background Tiling
+
+status: completed
+
+## Context
+
+The scrolling backgrounds changed each sprite's size independently during every
+frame update. Initial x-positions still came from the texture width, and scene
+resizes did not re-establish adjacency. Under `.resizeFill`, rotation or another
+view-size change could therefore leave a gap or overlap between the two tiles.
+
+## Design
+
+- Collect exactly the two named background sprites and sort them by x-position.
+- Reject non-finite or non-positive scene geometry before layout.
+- Normalize the leading tile into the interval immediately behind or at the
+  scene origin, preserving its current scroll phase.
+- Size both sprites from `SKScene.size` and place the second exactly one scene
+  width after the first.
+- Apply the helper after initial node creation and from `didChangeSize(_:)`.
+- Keep per-frame scrolling responsible only for movement and wraparound.
+
+## Test First
+
+The portable baseline first required a shared tiling helper, finite geometry,
+phase normalization, initial and resize calls, exact adjacency, and removal of
+per-frame resizing. The unchanged source failed this red-first contract.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- All four Make gates passed from `/tmp` through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py` passed.
+- `sh -n scripts/run-projectile-math-tests.sh` passed.
+- Seven isolated hostile mutations were rejected: removed initial layout, removed
+  resize layout, removed x-order sorting, removed scene sizing, weakened exact
+  adjacency, removed constant-time phase normalization, and restored per-frame
+  resizing.
+- `git diff --check` passed.
+- Local `swiftc` and `xcodebuild` were unavailable; hosted macOS remains
+  authoritative for executable Swift tests and the unsigned simulator build.
+
+## Scope Boundaries
+
+- No scroll speed, background asset, player, score, projectile, monster,
+  collision, audio, transition, persistence, network, signing, or project
+  metadata change.
+- Existing monsters and projectiles are not repositioned during resize.
+- Runtime rotation still benefits from manual simulator confirmation.
+
+## Primary Sources
+
+- Apple, `SKScene.didChangeSize(_:)`:
+  https://developer.apple.com/documentation/spritekit/skscene/didchangesize%28_%3A%29
+- Apple, `SKScene.size`:
+  https://developer.apple.com/documentation/spritekit/skscene/size

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -33,6 +33,7 @@ PROJECTILE_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-projectile-math-
 SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md"
 ACTIVE_GAME_OVER_PLAN = ROOT / "docs/plans/2026-06-18-active-game-over-presentation.md"
 RESIZE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-25-resize-safe-persistent-layout.md"
+BACKGROUND_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-background-tiling.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -167,6 +168,7 @@ def main():
         "docs/plans/2026-06-16-executable-projectile-math-tests.md",
         "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md",
         "docs/plans/2026-06-25-resize-safe-persistent-layout.md",
+        "docs/plans/2026-06-26-resize-safe-background-tiling.md",
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
@@ -231,6 +233,7 @@ def main():
     scene_aware_distance_plan = SCENE_AWARE_DISTANCE_PLAN.read_text(encoding="utf-8") if SCENE_AWARE_DISTANCE_PLAN.exists() else ""
     active_game_over_plan = ACTIVE_GAME_OVER_PLAN.read_text(encoding="utf-8") if ACTIVE_GAME_OVER_PLAN.exists() else ""
     resize_layout_plan = RESIZE_LAYOUT_PLAN.read_text(encoding="utf-8") if RESIZE_LAYOUT_PLAN.exists() else ""
+    background_resize_plan = BACKGROUND_RESIZE_PLAN.read_text(encoding="utf-8") if BACKGROUND_RESIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -278,6 +281,33 @@ def main():
             "view.frame.width" not in game_scene_contracts and
             "view.frame.height" not in game_scene_contracts,
             "GameScene must relayout the player and score from scene size changes",
+            failures)
+    background_layout_index = game_scene_contracts.find("func layoutScrollingBackground()")
+    background_layout_end = game_scene_contracts.find("func random(", background_layout_index)
+    background_layout_body = game_scene_contracts[background_layout_index:background_layout_end]
+    initialize_background_index = game_scene_contracts.find("func initializingScrollingBackground()")
+    initialize_background_end = game_scene_contracts.find("func moveBackground()", initialize_background_index)
+    initialize_background_body = game_scene_contracts[initialize_background_index:initialize_background_end]
+    move_background_end = game_scene_contracts.find("override func update", initialize_background_end)
+    move_background_body = game_scene_contracts[initialize_background_end:move_background_end]
+    require(background_layout_index != -1 and background_layout_end != -1 and
+            "children.compactMap" in background_layout_body and
+            'child.name == "background"' in background_layout_body and
+            "sorted { $0.position.x < $1.position.x }" in background_layout_body and
+            "guard backgrounds.count == 2" in background_layout_body and
+            "size.width.isFinite" in background_layout_body and
+            "size.height.isFinite" in background_layout_body and
+            "size.width > 0" in background_layout_body and
+            "size.height > 0" in background_layout_body and
+            "backgrounds[0].position.x.truncatingRemainder(" in background_layout_body and
+            "dividingBy: size.width" in background_layout_body and
+            "if leadingX > 0" in background_layout_body and
+            "background.size = size" in background_layout_body and
+            "leadingX + CGFloat(index) * size.width" in background_layout_body and
+            "layoutScrollingBackground()" in initialize_background_body and
+            "layoutScrollingBackground()" in resize_body and
+            "bg.size = self.frame.size" not in move_background_body,
+            "scrolling background tiles must stay contiguous across scene size changes",
             failures)
     require("SKAction.playSoundFileNamed" in game_scene and "background-music-aac.caf" in game_scene,
             "GameScene must keep bundled sound playback references",
@@ -707,6 +737,22 @@ def main():
             re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b",
                       resize_layout_verification) is None,
             "resize-safe persistent layout plan must record completed local verification",
+            failures)
+    background_resize_verification = markdown_section(
+        background_resize_plan, "Verification Completed"
+    )
+    require("status: completed" in background_resize_plan and
+            "red-first" in background_resize_plan.lower() and
+            "Seven isolated hostile mutations were rejected" in background_resize_verification and
+            "All four Make gates passed from the checkout" in background_resize_verification and
+            "All four Make gates passed from `/tmp`" in background_resize_verification and
+            "python3 -m py_compile scripts/check-baseline.py" in background_resize_verification and
+            "sh -n scripts/run-projectile-math-tests.sh" in background_resize_verification and
+            "git diff --check" in background_resize_verification and
+            "Local `swiftc` and `xcodebuild` were unavailable" in background_resize_verification and
+            "resize-safe background" in readme.lower() and
+            "scrolling background tiles" in agent_guidance.lower(),
+            "resize-safe background tiling plan must record completed local verification",
             failures)
     require("status: completed" in undersized_spawn_plan and
             "All four Make gates" in undersized_spawn_plan and


### PR DESCRIPTION
## Summary
- Centralize scrolling-background size and adjacency on `SKScene.size`.
- Preserve the leading tile phase with constant-time normalization during initial layout and `.resizeFill` changes.
- Remove independent per-frame resizing while preserving movement speed and wraparound.
- Add a red-first, comment-aware contract and completed verification plan.

## Baseline
Background tiles could retain stale dimensions or adjacency after scene resizing because sizing and per-frame movement owned overlapping layout responsibilities.

## Improvements
Initial layout and resize handling now share one scene-size authority, preserve phase, and keep adjacent tiles contiguous without changing movement or wraparound semantics.

## Validation
- `python3 scripts/check-baseline.py`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n scripts/run-projectile-math-tests.sh`
- `/usr/bin/make lint`, `test`, `build`, and `check` from the checkout and `/tmp`.
- Seven hostile mutations rejected across initialization, resize, ordering, sizing, adjacency, phase normalization, and per-frame ownership.
- `git diff --check`

## Risk
No scroll speed, asset, player, score, projectile, monster, collision, audio, transition, project, signing, persistence, or network behavior changed. Local `swiftc` and `xcodebuild` were unavailable.

## Follow-Ups
Keep hosted macOS as the authority for the executable harness and unsigned simulator build, and retain the single resize/layout ownership contract when scene sizing changes.
