### PR TITLE
Reject invalid scene width during monster spawn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ player launches emoji projectiles at moving targets.
   contact-delegate, and presentation side effects.
 - Keep persistent player and score positions derived from `SKScene.size`, and
   reapply them from `didChangeSize(_:)` when `.resizeFill` resizes the scene.
+- Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
 - Keep the two scrolling background tiles contiguous after initial setup and
   every scene-size change without resizing them independently per frame.
 - This is an Apple platform sample. Xcode, Swift, and deployment target versions

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-26 - P1 - Reject invalid scene width during enemy spawn
+
+- Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
+- Extended the red-first spawn helper contract beyond vertical range safety to
+  the horizontal position input used by `addMonster()`.
+
 ## 2026-06-26
 
 - Centralized scrolling background sizing and adjacency on `SKScene.size`.

--- a/EmojiThrower/GameScene.swift
+++ b/EmojiThrower/GameScene.swift
@@ -140,7 +140,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     func monsterSpawnY(spriteHeight: CGFloat) -> CGFloat? {
-        guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else {
+        guard spriteHeight.isFinite,
+            size.width.isFinite, size.height.isFinite,
+            size.width > 0, spriteHeight > 0 else {
             return nil
         }
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.
 - Enemy spawning skips invalid or undersized scene geometry before constructing
   a random range or adding a SpriteKit node.
+- Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
 
 ## Maintenance Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,7 @@ Helpful reports include:
 - `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, scene-size-driven player and score layout, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - Active-scene game-over ownership prevents detached scenes from mutating
   terminal gameplay state without an authoritative presentation target.
+- Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Stop enemy spawning as soon as game-over presentation starts
 - Skip enemy spawning when invalid or undersized scene geometry cannot contain
   the monster sprite
+- Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
 - Reject non-finite touch vectors before projectile side effects
 - Keep background scroll movement running per-frame until game over
 - Keep both scrolling background tiles contiguous when the scene size changes

--- a/docs/plans/2026-06-26-invalid-scene-width-spawn-guard-design.md
+++ b/docs/plans/2026-06-26-invalid-scene-width-spawn-guard-design.md
@@ -1,0 +1,24 @@
+# Invalid Scene Width Spawn Guard Design
+
+Status: Completed
+
+## Problem
+
+`monsterSpawnY` rejects unusable vertical geometry before `addMonster` creates a
+node, but `addMonster` also uses `size.width` to derive the monster's off-screen
+x position. A transient zero, negative, NaN, or infinite width can therefore
+pass the helper and create a monster with unusable horizontal geometry.
+
+## Options
+
+1. Validate width after adding the node. This permits invalid scene mutation.
+2. Add a separate width guard in `addMonster`. This splits spawn geometry
+   authority across two locations.
+3. Extend the existing optional spawn-geometry helper to reject invalid width
+   before returning a valid y coordinate.
+
+## Decision
+
+Use option 3. Preserve normal spawn cadence, random vertical placement, speed,
+physics, scoring, and assets while keeping all scene-geometry admission ahead
+of node insertion.

--- a/docs/plans/2026-06-26-invalid-scene-width-spawn-guard.md
+++ b/docs/plans/2026-06-26-invalid-scene-width-spawn-guard.md
@@ -1,0 +1,42 @@
+# Invalid Scene Width Spawn Guard
+
+Status: Completed
+
+## Goal
+
+Prevent enemy creation when the scene width cannot produce a valid off-screen
+monster position.
+
+## Work
+
+- Extended `monsterSpawnY` to require finite positive scene width.
+- Kept the optional helper guard ahead of `addChild(monster)` and all physics or
+  movement side effects.
+- Added a red-first static contract for the horizontal geometry inputs.
+- Updated maintained agent, README, security, vision, and change guidance.
+- Added completed-plan and guidance checks to the canonical baseline.
+
+## Verification
+
+- Run all four Make aliases from the repository root and an external directory.
+- Reject hostile scene-width spawn mutations across finite, positive, ordering,
+  guidance, and plan contracts.
+- Run projectile math tests when `swiftc` is available.
+- Audit Python/shell syntax, whitespace, generated artifacts, and secret-shaped
+  additions.
+
+## Completion Evidence
+
+- Before implementation, the baseline failed because `monsterSpawnY` did not
+  require finite positive scene width.
+- After implementation, the portable baseline passed.
+- The repository-root and external-directory `make check` passed, and all four
+  Make aliases passed from both invocation locations.
+- Six hostile scene-width spawn mutations were rejected across finite-width,
+  positive-width, zero-width, optional guard, guidance, and plan-status
+  contracts.
+- Python and shell syntax, whitespace, generated-artifact, and likely-secret
+  audits passed.
+- Native SpriteKit execution was not performed because Xcode is unavailable
+  locally. Executable projectile math was also skipped because `swiftc` is
+  unavailable; hosted checks must pass on the exact pull request head.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -34,6 +34,7 @@ SCENE_AWARE_DISTANCE_PLAN = ROOT / "docs/plans/2026-06-17-020-fix-scene-aware-pr
 ACTIVE_GAME_OVER_PLAN = ROOT / "docs/plans/2026-06-18-active-game-over-presentation.md"
 RESIZE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-25-resize-safe-persistent-layout.md"
 BACKGROUND_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-background-tiling.md"
+SPAWN_WIDTH_PLAN = ROOT / "docs/plans/2026-06-26-invalid-scene-width-spawn-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -234,6 +235,7 @@ def main():
     active_game_over_plan = ACTIVE_GAME_OVER_PLAN.read_text(encoding="utf-8") if ACTIVE_GAME_OVER_PLAN.exists() else ""
     resize_layout_plan = RESIZE_LAYOUT_PLAN.read_text(encoding="utf-8") if RESIZE_LAYOUT_PLAN.exists() else ""
     background_resize_plan = BACKGROUND_RESIZE_PLAN.read_text(encoding="utf-8") if BACKGROUND_RESIZE_PLAN.exists() else ""
+    spawn_width_plan = SPAWN_WIDTH_PLAN.read_text(encoding="utf-8") if SPAWN_WIDTH_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -333,7 +335,9 @@ def main():
             "GameScene must guard enemy spawning after game over before creating sprites",
             failures)
     require(spawn_y_index != -1 and next_helper_index != -1 and
-            "guard spriteHeight.isFinite, size.height.isFinite, spriteHeight > 0 else" in spawn_y_body and
+            "guard spriteHeight.isFinite," in spawn_y_body and
+            "size.width.isFinite, size.height.isFinite," in spawn_y_body and
+            "size.width > 0, spriteHeight > 0 else" in spawn_y_body and
             "let minY = spriteHeight / 2" in spawn_y_body and
             "let maxY = size.height - minY" in spawn_y_body and
             "guard minY <= maxY else" in spawn_y_body and
@@ -759,6 +763,23 @@ def main():
             "hostile mutations" in undersized_spawn_plan.lower(),
             "undersized scene spawn plan must record completed status and verification",
             failures)
+    require("Status: Completed" in spawn_width_plan and
+            "repository-root and external-directory `make check` passed" in spawn_width_plan and
+            "hostile scene-width spawn mutations" in spawn_width_plan and
+            "Native SpriteKit execution was not performed" in spawn_width_plan,
+            "scene-width spawn plan must record completed verification evidence",
+            failures)
+    spawn_width_guidance = "Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position."
+    for relative_path, document in [
+        ("AGENTS.md", agent_guidance),
+        ("README.md", readme),
+        ("SECURITY.md", security),
+        ("VISION.md", vision),
+        ("CHANGES.md", changes),
+    ]:
+        require(spawn_width_guidance in document,
+                f"{relative_path} must document scene-width spawn validation",
+                failures)
     location_make_statuses = re.findall(
         r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE
     )


### PR DESCRIPTION
## Summary
- require finite positive scene width in the existing monster spawn geometry helper
- prevent zero, negative, NaN, or infinite widths from creating monsters at invalid horizontal positions
- preserve normal vertical placement, cadence, physics, scoring, and assets with fail-closed contracts and guidance

## Verification
- red-first baseline reproduced the missing width validation
- all four Make aliases passed from the repository root and an external directory
- six hostile finite, positive, zero-width, optional-guard, guidance, and plan mutations were rejected
- Python/shell syntax, whitespace, generated-artifact, and likely-secret audits passed

## Runtime boundary
- executable Swift projectile tests skipped locally because `swiftc` is unavailable
- native SpriteKit/Xcode execution skipped locally; hosted macOS remains authoritative
