### PR TITLE
fix: keep game-over geometry resize-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ player launches emoji projectiles at moving targets.
 - Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
 - Keep the two scrolling background tiles contiguous after initial setup and
   every scene-size change without resizing them independently per frame.
+- The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.
 - This is an Apple platform sample. Xcode, Swift, and deployment target versions
   must stay aligned with the checked-in project settings.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2026-06-26 15:55 - P1 - Keep game-over geometry current across resize
+
+- The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.
+- Added red-first source contracts for resize relayout and current-size delayed restart.
+- Preserved result copy, delay, transition, active-scene restart ownership, and `.resizeFill` behavior.
+- Six hostile mutations covering scene-owned label state, resize callback,
+  current-center geometry, current-size restart, guidance, and plan status were
+  rejected.
+- All four Make aliases and external-directory `make check`, Python/shell
+  syntax, and `git diff --check` passed. Local `swiftc` and `xcodebuild` were
+  unavailable, so hosted macOS remains authoritative.
+- Hosted push baseline `28269675521`, pull-request baseline `28269677372`, and
+  CodeQL run `28269677126` passed on implementation head
+  `52f900b4c7cfb73e80cc7e8cdbbd1c3ee5f3fc76`, including Swift analysis.
+- Codex review stopped before analysis with OpenAI HTTP 401; immutable manual
+  review found no actionable issues.
+
 ## 2026-06-26 - P1 - Reject invalid scene width during enemy spawn
 
 - Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.

--- a/EmojiThrower/GameOverScene.swift
+++ b/EmojiThrower/GameOverScene.swift
@@ -6,6 +6,7 @@ import Foundation
 import SpriteKit
 
 class GameOverScene: SKScene {
+    let resultLabel = SKLabelNode(fontNamed: "Helvetica")
     
     init(size: CGSize, won: Bool) {
         
@@ -15,21 +16,29 @@ class GameOverScene: SKScene {
 
         let message = won ? "You Won!" : "You Lose!"
 
-        let label = SKLabelNode(fontNamed: "Helvetica")
-        label.text = message
-        label.fontSize = 40
-        label.fontColor = .black
-        label.position = CGPoint(x: size.width/2, y: size.height/2)
-        addChild(label)
+        resultLabel.text = message
+        resultLabel.fontSize = 40
+        resultLabel.fontColor = .black
+        addChild(resultLabel)
+        layoutResultLabel()
 
         run(SKAction.sequence([
             SKAction.wait(forDuration: 3.0),
             SKAction.run {
                 let reveal = SKTransition.flipHorizontal(withDuration: 0.2)
-                self.restartGame(size: size, transition: reveal)
+                self.restartGame(size: self.size, transition: reveal)
             }
             ]))
         
+    }
+
+    func layoutResultLabel() {
+        resultLabel.position = CGPoint(x: size.width/2, y: size.height/2)
+    }
+
+    override func didChangeSize(_ oldSize: CGSize) {
+        super.didChangeSize(oldSize)
+        layoutResultLabel()
     }
 
     func restartGame(size: CGSize, transition: SKTransition) -> Bool {

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ unsigned simulator build when Xcode is available.
   wide and tall scene bounds before its movement action completes.
 - Persistent player and score layout derives from the current scene size and is
   reapplied when `.resizeFill` changes that size, including iPad rotation.
+- The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.
 - This is a local game sample. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
@@ -163,6 +164,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   scene-size-driven player and score layout guardrail.
 - See `docs/plans/2026-06-26-resize-safe-background-tiling.md` for contiguous
   scrolling background layout across scene-size changes.
+- See `docs/plans/2026-06-26-resize-safe-game-over.md` for current-size result layout and delayed restart geometry.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions baseline.
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,7 @@ Helpful reports include:
 - Active-scene game-over ownership prevents detached scenes from mutating
   terminal gameplay state without an authoritative presentation target.
 - Enemy spawning rejects non-finite or non-positive scene width before deriving an off-screen monster position.
+- The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.
 - The pinned macOS GitHub Actions workflow uses read-only repository permissions
   and compiles an unsigned simulator build without executing gameplay,
   rendering, audio, physics, or signing operations.

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,7 @@ Priority:
 - Reject non-finite touch vectors before projectile side effects
 - Keep background scroll movement running per-frame until game over
 - Keep both scrolling background tiles contiguous when the scene size changes
+- The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.
 - Avoid adding account or network behavior without a clear purpose
 - Keep `scripts/check-baseline.py` passing for bundled resources, Xcode
   metadata, SpriteKit source inventory, local-only gameplay, contact handling,

--- a/docs/plans/2026-06-26-resize-safe-game-over-design.md
+++ b/docs/plans/2026-06-26-resize-safe-game-over-design.md
@@ -1,0 +1,21 @@
+# Resize-Safe Game Over Design
+
+Status: Completed
+
+## Problem
+
+`GameOverScene` creates a local label at its initial center and captures the
+initial size for its delayed restart. If `.resizeFill` changes the scene during
+the result delay, the label stays at the old center and the restart begins with
+stale geometry.
+
+## Options
+
+1. Keep initial geometry for the short result delay.
+2. Recenter only the label while retaining the captured restart size.
+3. Own the label as scene state, relayout from `didChangeSize(_:)`, and read `self.size` when the delayed restart fires.
+
+## Decision
+
+Use option 3 so all game-over geometry comes from the current scene while
+preserving the existing delay, transition, and active-scene restart guard.

--- a/docs/plans/2026-06-26-resize-safe-game-over.md
+++ b/docs/plans/2026-06-26-resize-safe-game-over.md
@@ -1,0 +1,35 @@
+# Resize-Safe Game Over
+
+status: completed
+
+## Goal
+
+Keep result-screen layout and delayed restart geometry aligned with the current
+game-over scene size.
+
+## Work
+
+- Promote the result label to scene-owned state.
+- Center it during initialization and every `didChangeSize(_:)` callback.
+- Read `self.size` when the delayed restart action fires.
+- Add source, guidance, hostile mutation, and plan contracts.
+
+## Verification
+
+- The red-first checker failed on the local label and captured restart size.
+- Six hostile game-over resize mutations covered scene-owned label state,
+  relayout, current-center geometry, current-size restart, guidance, and plan evidence.
+- All four Make aliases and repository-root and external-directory `make check` passed.
+- Python compilation, shell syntax, and `git diff --check` passed.
+- Local `swiftc` and `xcodebuild` were unavailable.
+
+Implementation head `52f900b4c7cfb73e80cc7e8cdbbd1c3ee5f3fc76` passed hosted
+push baseline `28269675521`, pull-request baseline `28269677372`, and CodeQL
+run `28269677126`, including Swift analysis. Codex review stopped before
+analysis with OpenAI HTTP 401; immutable manual review found no actionable
+issues. The final evidence-only head must repeat hosted validation.
+
+## Scope
+
+No gameplay scoring, collision, audio, asset, transition, network, persistence,
+project setting, or scene-ownership behavior changed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -35,6 +35,7 @@ ACTIVE_GAME_OVER_PLAN = ROOT / "docs/plans/2026-06-18-active-game-over-presentat
 RESIZE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-25-resize-safe-persistent-layout.md"
 BACKGROUND_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-background-tiling.md"
 SPAWN_WIDTH_PLAN = ROOT / "docs/plans/2026-06-26-invalid-scene-width-spawn-guard.md"
+GAME_OVER_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-game-over.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -236,6 +237,7 @@ def main():
     resize_layout_plan = RESIZE_LAYOUT_PLAN.read_text(encoding="utf-8") if RESIZE_LAYOUT_PLAN.exists() else ""
     background_resize_plan = BACKGROUND_RESIZE_PLAN.read_text(encoding="utf-8") if BACKGROUND_RESIZE_PLAN.exists() else ""
     spawn_width_plan = SPAWN_WIDTH_PLAN.read_text(encoding="utf-8") if SPAWN_WIDTH_PLAN.exists() else ""
+    game_over_resize_plan = GAME_OVER_RESIZE_PLAN.read_text(encoding="utf-8") if GAME_OVER_RESIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -548,11 +550,34 @@ def main():
             "GameViewController must keep SpriteKit debug overlays disabled",
             failures)
     game_over_scene = read("EmojiThrower/GameOverScene.swift")
+    require("let resultLabel = SKLabelNode(fontNamed: \"Helvetica\")" in game_over_scene and
+            "func layoutResultLabel()" in game_over_scene and
+            "override func didChangeSize(_ oldSize: CGSize)" in game_over_scene and
+            "resultLabel.position = CGPoint(x: size.width/2, y: size.height/2)" in game_over_scene and
+            "self.restartGame(size: self.size, transition: reveal)" in game_over_scene,
+            "GameOverScene must relayout its label and restart from current scene size",
+            failures)
+    require("status: completed" in game_over_resize_plan and
+            "red-first" in game_over_resize_plan.lower() and
+            "hostile game-over resize mutations" in game_over_resize_plan.lower(),
+            "game-over resize plan must record completed verification evidence",
+            failures)
+    game_over_resize_guidance = "The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry."
+    for relative_path, document in [
+        ("AGENTS.md", agent_guidance),
+        ("README.md", readme),
+        ("SECURITY.md", security),
+        ("VISION.md", vision),
+        ("CHANGES.md", changes),
+    ]:
+        require(game_over_resize_guidance in document,
+                f"{relative_path} must document resize-safe game-over geometry",
+                failures)
     require("func restartGame(size: CGSize, transition: SKTransition) -> Bool" in game_over_scene and
             "guard let view = self.view, view.scene === self else" in game_over_scene and
             "scene.scaleMode = .resizeFill" in game_over_scene and
             "view.presentScene(scene, transition: transition)" in game_over_scene and
-            "self.restartGame(size: size, transition: reveal)" in game_over_scene,
+            "self.restartGame(size: self.size, transition: reveal)" in game_over_scene,
             "GameOverScene must guard delayed restarts and keep restart scale mode aligned",
             failures)
     require(not re.search(r"\b(?:print|println|NSLog)\s*\(", swift_sources),


### PR DESCRIPTION
## Summary
- retain the result label as scene-owned state and recenter it after size changes
- use the current game-over scene size when the delayed restart fires
- add red-first source contracts and six hostile resize mutations

## Validation
- `make lint`, `make test`, `make build`, `make check`
- external-directory `make -f <repo>/Makefile check`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n scripts/run-projectile-math-tests.sh`
- `git diff --check`

Local Swift/Xcode execution was unavailable; hosted macOS build validation remains authoritative.
