### PR TITLE
security: preserve historical Google key response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ xcuserdata/
 .DS_Store
 *.local.xcconfig
 *.secrets.xcconfig
+GoogleService-Info.plist
 .env
 .env.*
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,10 @@ player launches emoji projectiles at moving targets.
 
 ## Safety and gotchas
 
-- No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
+- No required secret or credential file is needed for current gameplay. Keep
+  `GoogleService-Info.plist` and any future integration secrets out of git.
+- Historical Google API key alerts must remain open until the credential owner
+  verifies provider-side revocation or rotation.
 - Debug logging from launch and gameplay paths should stay removed; score should remain visible in-game rather than printed to the console.
 - Runtime debug overlays should stay disabled outside explicit troubleshooting builds.
 - Resource changes should keep image, sound, font, scene, and Xcode project references aligned, with fallback behavior for optional image helper rendering.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,66 @@
 # Changes
 
+## 2026-06-26 17:52 PDT - P1 - Preserve historical Google key response
+
+### Summary
+
+Formalized the unresolved owner-response boundary for the historical Google API
+key alert without exposing the value or claiming provider-side remediation.
+
+### Work completed
+
+- Added the retired Google service credential filename to `.gitignore`.
+- Synchronized the revocation/rotation requirement across maintained security
+  and contributor guidance.
+- Added a static baseline contract and completed design/implementation evidence.
+
+### Threads
+
+- None; the alert metadata, current default branch, and maintained verifier were
+  audited directly.
+
+### Files changed
+
+- `.gitignore` — excludes `GoogleService-Info.plist`.
+- `scripts/check-baseline.py` — enforces the ignore and owner-response contract.
+- `README.md`, `SECURITY.md`, and `AGENTS.md` — preserve the unresolved
+  provider-action boundary.
+- `docs/plans/2026-06-26-historical-google-key-response-design.md` and
+  `docs/plans/2026-06-26-historical-google-key-response.md` — record the
+  decision, scope, and verification plan.
+
+### Validation
+
+- GitHub secret-scanning metadata — the alert points to repository history, has
+  unknown validity, and remains open.
+- Current `master` review — the flagged credential file is absent.
+- Red-first `make check` — rejected the missing ignore entry, guidance, and
+  completed response evidence.
+- `make check`, `make lint`, `make test`, and `make build` — passed the static
+  SpriteKit baseline; local `swiftc` and `xcodebuild` skipped truthfully.
+- `/usr/bin/make -C /tmp -f "$PWD/Makefile" check` — passed from an external
+  caller directory.
+- Ignore-entry and security-guidance hostile mutations — both rejected.
+- Python AST parsing, shell syntax, and `git diff --check` — passed.
+- `gitleaks detect --source . --no-git --redact` — no current-tree leaks found.
+
+### Bugs / findings
+
+- P1 security response gap: a README-only HOLD was not enforced by the baseline
+  or repeated in the security policy and contributor guidance.
+- Historical Google API key alerts must remain open until the credential owner
+  verifies provider-side revocation or rotation.
+
+### Blockers
+
+- Only the credential owner can verify provider-side revocation or rotation;
+  this change intentionally does not resolve the GitHub alert.
+
+### Next action
+
+- Complete local and hosted validation, run review on the exact head, and merge
+  the focused security-response PR if all gates pass.
+
 ## 2026-06-26 15:55 - P1 - Keep game-over geometry current across resize
 
 - The game-over label follows the current scene center after resize, and delayed restart uses the current game-over scene size instead of captured pre-resize geometry.

--- a/README.md
+++ b/README.md
@@ -124,10 +124,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - Current `master` requires no credential file for local gameplay. If you add
   integrations later, keep secrets out of git.
-- The repository remains under a separate credential-response HOLD. An owner
-  must verify and revoke or rotate the affected Google credential with the
-  provider before resolving the corresponding GitHub alert. This documentation
-  correction does not complete or replace that remediation.
+- Historical Google API key alerts must remain open until the credential owner
+  verifies provider-side revocation or rotation. This repository guidance does
+  not complete or replace that provider action.
 
 ## Security and Privacy Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,9 @@ Helpful reports include:
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
+- Historical Google API key alerts must remain open until the credential owner
+  verifies provider-side revocation or rotation. Current-tree cleanup and
+  documentation are not evidence that the provider credential was revoked.
 - Debug logging and runtime debug overlays should stay removed from normal gameplay paths; use visible in-game state for score feedback instead of console output.
 - `make check` runs a static baseline that guards bundled resource references, image helper fallbacks, non-finite touch vectors, game-over restart handling, collision handler game-over guards, contact delegate cleanup, spawn lifecycle guards, invalid or undersized scene spawn geometry, scene-size-driven player and score layout, per-frame background scroll movement, plist/storyboard metadata, Xcode project wiring, source inventory, debug logging, and local-only gameplay behavior when Xcode is unavailable.
 - Active-scene game-over ownership prevents detached scenes from mutating

--- a/docs/plans/2026-06-26-historical-google-key-response-design.md
+++ b/docs/plans/2026-06-26-historical-google-key-response-design.md
@@ -1,0 +1,27 @@
+# Historical Google Key Response Design
+
+Status: Completed
+
+## Evidence
+
+GitHub secret scanning reports one open historical Google API key alert. The
+flagged credential file is absent from current `master`, and the alert validity
+is unknown. The repository owner has not supplied provider-side revocation or
+rotation evidence.
+
+## Options
+
+1. Resolve the alert as revoked without provider evidence.
+2. Leave the existing README sentence unenforced.
+3. Keep the alert open, ignore the retired credential filename, and enforce the
+   owner-response boundary across maintained security guidance and verification.
+
+## Decision
+
+Use option 3. It improves current-tree prevention and maintainer clarity without
+exposing the value or making an unsupported provider-side claim.
+
+## Scope
+
+No credential value, alert location, gameplay source, Xcode project setting,
+network behavior, or repository history is changed.

--- a/docs/plans/2026-06-26-historical-google-key-response.md
+++ b/docs/plans/2026-06-26-historical-google-key-response.md
@@ -1,0 +1,83 @@
+# Historical Google Key Response Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve the unresolved historical Google API key response boundary and prevent the retired credential file from being committed again.
+
+**Architecture:** The static baseline owns the repository contract. It requires the ignored credential filename, completed response evidence, and identical owner-action guidance in maintained security documents while leaving provider-side resolution outside the repository.
+
+**Tech Stack:** Python 3 static verifier, Markdown guidance, gitignore.
+
+status: completed
+
+---
+
+### Task 1: Add the failing security contract
+
+**Files:**
+- Modify: `scripts/check-baseline.py`
+
+**Step 1: Write the failing test**
+
+Require the response plan, the ignored `GoogleService-Info.plist` filename, and
+owner-action guidance in README, SECURITY, AGENTS, and CHANGES.
+
+**Step 2: Run test to verify it fails**
+
+Run: `make check`
+Expected: FAIL because the ignore entry and maintained guidance are missing.
+
+### Task 2: Implement the minimal repository response
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `AGENTS.md`
+- Modify: `SECURITY.md`
+- Modify: `CHANGES.md`
+- Verify: `README.md`
+
+**Step 1: Add the ignored retired filename**
+
+Add `GoogleService-Info.plist` without adding a credential template because the
+current local game needs no Google integration.
+
+**Step 2: Synchronize owner-action guidance**
+
+State that the historical alert remains open until the credential owner verifies
+provider-side revocation or rotation. Do not publish the value or claim the
+provider action occurred.
+
+### Task 3: Verify and close the plan
+
+**Files:**
+- Modify: `docs/plans/2026-06-26-historical-google-key-response.md`
+
+**Step 1: Run focused and full gates**
+
+Run: `make check`
+Expected: PASS after marking the plan completed with actual verification.
+
+Run: `/usr/bin/make -C /tmp -f "$PWD/Makefile" check`
+Expected: PASS from an external caller directory.
+
+Run: `git diff --check`
+Expected: PASS.
+
+**Step 2: Commit**
+
+Commit the focused security response and open a pull request for exact-head
+hosted validation and review.
+
+## Verification Completed
+
+- Red-first `make check` failed on the missing ignored credential filename,
+  maintained owner-response guidance, and completed plan evidence.
+- After implementation, all four Make aliases passed the static SpriteKit gate.
+- External-directory `make check` passed through the absolute Makefile path.
+- Two isolated hostile mutations were rejected: removing the ignored credential
+  filename and removing the security-policy response sentence.
+- Python AST parsing, shell syntax, and `git diff --check` passed.
+- Local `swiftc` and `xcodebuild` were unavailable; hosted macOS remains the
+  native compilation authority.
+- Provider-side revocation or rotation remains an owner-only blocker and was not
+  claimed or used to resolve the open alert.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -36,6 +36,7 @@ RESIZE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-25-resize-safe-persistent-layout
 BACKGROUND_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-background-tiling.md"
 SPAWN_WIDTH_PLAN = ROOT / "docs/plans/2026-06-26-invalid-scene-width-spawn-guard.md"
 GAME_OVER_RESIZE_PLAN = ROOT / "docs/plans/2026-06-26-resize-safe-game-over.md"
+GOOGLE_KEY_RESPONSE_PLAN = ROOT / "docs/plans/2026-06-26-historical-google-key-response.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -171,6 +172,8 @@ def main():
         "docs/plans/2026-06-17-020-fix-scene-aware-projectile-distance-plan.md",
         "docs/plans/2026-06-25-resize-safe-persistent-layout.md",
         "docs/plans/2026-06-26-resize-safe-background-tiling.md",
+        "docs/plans/2026-06-26-historical-google-key-response-design.md",
+        "docs/plans/2026-06-26-historical-google-key-response.md",
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
@@ -238,6 +241,7 @@ def main():
     background_resize_plan = BACKGROUND_RESIZE_PLAN.read_text(encoding="utf-8") if BACKGROUND_RESIZE_PLAN.exists() else ""
     spawn_width_plan = SPAWN_WIDTH_PLAN.read_text(encoding="utf-8") if SPAWN_WIDTH_PLAN.exists() else ""
     game_over_resize_plan = GAME_OVER_RESIZE_PLAN.read_text(encoding="utf-8") if GAME_OVER_RESIZE_PLAN.exists() else ""
+    google_key_response_plan = GOOGLE_KEY_RESPONSE_PLAN.read_text(encoding="utf-8") if GOOGLE_KEY_RESPONSE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") == 2 and
@@ -595,6 +599,9 @@ def main():
     require("*.local.xcconfig" in gitignore and ".env" in gitignore and "DerivedData" in gitignore,
             ".gitignore must exclude local config and Xcode build products",
             failures)
+    require("GoogleService-Info.plist" in gitignore.splitlines(),
+            ".gitignore must exclude the retired Google credential file",
+            failures)
     require(".PHONY: build check lint test" in makefile and
             "SWIFTC ?= swiftc" in makefile and
             "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
@@ -654,6 +661,25 @@ def main():
     require(all("active-scene game-over ownership" in document
                 for document in normalized_guidance),
             "project guidance must document active-scene game-over ownership",
+            failures)
+    google_key_response_guidance = (
+        "historical google api key alerts must remain open until the credential "
+        "owner verifies provider-side revocation or rotation."
+    )
+    for relative_path, document in [
+        ("README.md", readme),
+        ("SECURITY.md", security),
+        ("AGENTS.md", agent_guidance),
+        ("CHANGES.md", changes),
+    ]:
+        require(google_key_response_guidance in " ".join(document.lower().split()),
+                f"{relative_path} must document the historical Google key response boundary",
+                failures)
+    require("status: completed" in google_key_response_plan and
+            "provider-side revocation or rotation" in google_key_response_plan and
+            "make check" in google_key_response_plan and
+            "git diff --check" in google_key_response_plan,
+            "historical Google key response plan must record completed verification",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "EmojiThrower.xcodeproj" in readme and "SpriteKit" in readme and
             "image" in readme.lower() and "game-over" in readme.lower() and "spawn" in readme.lower() and


### PR DESCRIPTION
## Summary
- keep the historical Google API key alert open until the credential owner verifies provider-side revocation or rotation
- ignore the retired `GoogleService-Info.plist` filename so it is not recommitted
- enforce the owner-response boundary across maintained guidance and the static baseline

## Evidence
- GitHub secret scanning points to repository history; current validity is unknown
- the flagged credential file is absent from current `master`
- this PR does not expose the value, rewrite history, claim revocation, or resolve the alert

## Validation
- red-first `make check` rejected the missing ignore, guidance, and completed evidence
- `make check`, `make lint`, `make test`, and `make build`
- external-directory absolute-Makefile `make check`
- two hostile mutations: ignore removal and security-guidance removal
- Python AST parsing, shell syntax, `git diff --check`
- current-tree gitleaks: zero findings

## Blocker
Only the credential owner can verify provider-side revocation or rotation. The GitHub alert intentionally remains open after this repository-only change.
