### PR TITLE
Fix Make roots containing spaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ player launches emoji projectiles at moving targets.
 - Full baseline: `make check` (includes an unsigned simulator build when Xcode
   is available)
 - Make gates support absolute checkout paths containing spaces; preserve the
-  encoded `MAKEFILE_LIST` root derivation and recursive regression.
+  single-Makefile authority boundary and recursive regression.
 - Local Apple development: `open EmojiThrower.xcodeproj`
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ player launches emoji projectiles at moving targets.
 - Install dependencies: no repository-specific install command is documented.
 - Full baseline: `make check` (includes an unsigned simulator build when Xcode
   is available)
+- Make gates support absolute checkout paths containing spaces; preserve the
+  encoded `MAKEFILE_LIST` root derivation and recursive regression.
 - Local Apple development: `open EmojiThrower.xcodeproj`
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Preserved absolute Makefile roots containing spaces and added a recursive-safe
   baseline regression without changing gameplay or credential handling.
+- Rejected ambiguous Makefile inputs so later recipes cannot replace verification.
 
 ## 2026-06-26 17:52 PDT - P1 - Preserve historical Google key response
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+- Preserved absolute Makefile roots containing spaces and added a recursive-safe
+  baseline regression without changing gameplay or credential handling.
+
 ## 2026-06-26 17:52 PDT - P1 - Preserve historical Google key response
 
 ### Summary

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,30 @@
-.PHONY: build check lint test
+.PHONY: __repository-make-authority build check lint test
+.SECONDEXPANSION:
 
 SWIFTC ?= swiftc
-override empty :=
-override space := $(empty) $(empty)
-override makefile_space := __IOS_EMOJI_THROWER_MAKEFILE_SPACE__
-override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
-override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell sed_path=/usr/bin/sed; [ -x "$$sed_path" ] || sed_path=/bin/sed; [ -x "$$sed_path" ] || exit 1; path=$$(printf '%s' '$(subst ','"'"',$(value MAKEFILE_LIST))' | "$$sed_path" 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile must be loaded alone)
+endif
 
-lint test build: check
+build check lint test:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check lint test:: $$(if $$(shell sed_path=/usr/bin/sed && [ -x "$$$$sed_path" ] || sed_path=/bin/sed && [ -x "$$$$sed_path" ] && path=$$$$(printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | "$$$$sed_path" 's/^ //') && [ -f "$$$$path" ] && printf '%s' ok),,$$(error repository Makefile must be loaded alone))
+build check lint test:: __repository-make-authority
 
-check:
+__repository-make-authority::
+	@:
+
+lint test build:: check
+
+check::
 	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-projectile-math-tests.sh"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .PHONY: build check lint test
 
 SWIFTC ?= swiftc
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override empty :=
+override space := $(empty) $(empty)
+override makefile_space := __IOS_EMOJI_THROWER_MAKEFILE_SPACE__
+override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
+override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
 
 lint test build: check
 
@@ -12,3 +16,4 @@ check:
 		echo "swiftc unavailable; executable projectile math tests skipped"; \
 	fi
 	python3 "$(ROOT)/scripts/check-baseline.py"
+	python3 "$(ROOT)/scripts/test-make-spaced-path.py"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   simulator-build migration.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, plist/storyboard files, SpriteKit assets, sounds, fonts, Xcode metadata, or gameplay/privacy documentation.
 - The same gates may be invoked through an absolute Makefile path from another
-  directory; verification resolves the checker relative to the checkout.
+  directory, including when the checkout path contains spaces; verification
+  resolves the checker relative to the checkout.
 
 ## Contributing
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -12,8 +12,8 @@ also splits loaded absolute Makefile paths containing spaces.
 
 ## Scope
 
-1. Derive the checkout root from an encoded loaded Makefile path that preserves
-   spaces.
+1. Derive the checkout root from the single loaded Makefile path while
+   preserving spaces.
 2. Invoke the baseline checker from that root for every Make alias.
 3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
 4. Preserve SpriteKit behavior, project metadata, resources, and workflow
@@ -31,8 +31,8 @@ also splits loaded absolute Makefile paths containing spaces.
 
 ## Work Completed
 
-- Derived the checkout root from the loaded Makefile and invoked the baseline
-  checker by absolute path.
+- Derived the checkout root from the sole loaded Makefile, rejected ambiguous
+  Makefile inputs, and invoked the baseline checker by absolute path.
 - Added exact Makefile, completed-plan, external-run, and synchronized guidance
   contracts without changing gameplay, project, resource, or workflow files.
 
@@ -41,6 +41,7 @@ also splits loaded absolute Makefile paths containing spaces.
 - All four Make gates passed from the checkout.
 - All four Make gates passed from `/tmp` through the absolute Makefile path.
 - GNU Make 4.2 and 4.4 space-containing absolute Makefile paths passed.
+- Preloaded, overridden, additional, and recipe-replacement Makefiles failed closed.
 - `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
   passed.
 - Local validation reported that `xcodebuild` was unavailable and therefore ran

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -7,11 +7,13 @@ status: completed
 Absolute Makefile invocations previously resolved `scripts/check-baseline.py`
 relative to the caller instead of the checkout. That made the documented
 verification aliases fail outside the repository directory even though the
-checker itself already derived the checkout root from its own path.
+checker itself already derived the checkout root from its own path. GNU Make
+also splits loaded absolute Makefile paths containing spaces.
 
 ## Scope
 
-1. Derive the checkout root from the loaded Makefile.
+1. Derive the checkout root from an encoded loaded Makefile path that preserves
+   spaces.
 2. Invoke the baseline checker from that root for every Make alias.
 3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
 4. Preserve SpriteKit behavior, project metadata, resources, and workflow
@@ -38,6 +40,7 @@ checker itself already derived the checkout root from its own path.
 
 - All four Make gates passed from the checkout.
 - All four Make gates passed from `/tmp` through the absolute Makefile path.
+- GNU Make 4.2 and 4.4 space-containing absolute Makefile paths passed.
 - `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
   passed.
 - Local validation reported that `xcodebuild` was unavailable and therefore ran

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -603,17 +603,18 @@ def main():
     require("GoogleService-Info.plist" in gitignore.splitlines(),
             ".gitignore must exclude the retired Google credential file",
             failures)
-    require(".PHONY: build check lint test" in makefile and
+    require(".PHONY: __repository-make-authority build check lint test" in makefile and
             "SWIFTC ?= swiftc" in makefile and
-            "override makefile_space := __IOS_EMOJI_THROWER_MAKEFILE_SPACE__" in makefile and
-            "override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))" in makefile and
-            "override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))" in makefile and
-            "lint test build: check" in makefile and
+            "MAKEFILES must be empty" in makefile and
+            "MAKEFILE_LIST must not be overridden" in makefile and
+            "repository Makefile must be loaded alone" in makefile and
+            ".SECONDEXPANSION:" in makefile and
+            "lint test build:: check" in makefile and
             '"$(ROOT)/scripts/run-projectile-math-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
             'python3 "$(ROOT)/scripts/test-make-spaced-path.py"' in makefile and
             "python3 scripts/check-baseline.py" not in makefile,
-            "Makefile must expose location-independent lint, test, build, and check aliases",
+            "Makefile must expose location-independent aliases with a single-Makefile authority boundary",
             failures)
     require("Status: Completed" in projectile_test_plan and
             "make check" in projectile_test_plan and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -177,6 +177,7 @@ def main():
         "docs/readme-overview.svg",
         "Tests/ProjectileMathTests/main.swift",
         "scripts/run-projectile-math-tests.sh",
+        "scripts/test-make-spaced-path.py",
     ]
 
     for relative_path in required_files:
@@ -604,10 +605,13 @@ def main():
             failures)
     require(".PHONY: build check lint test" in makefile and
             "SWIFTC ?= swiftc" in makefile and
-            "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "override makefile_space := __IOS_EMOJI_THROWER_MAKEFILE_SPACE__" in makefile and
+            "override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))" in makefile and
+            "override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))" in makefile and
             "lint test build: check" in makefile and
             '"$(ROOT)/scripts/run-projectile-math-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
+            'python3 "$(ROOT)/scripts/test-make-spaced-path.py"' in makefile and
             "python3 scripts/check-baseline.py" not in makefile,
             "Makefile must expose location-independent lint, test, build, and check aliases",
             failures)
@@ -840,6 +844,7 @@ def main():
     require(location_make_statuses == ["status: completed"] and
             "All four Make gates passed from the checkout" in location_make_verification and
             "All four Make gates passed from `/tmp` through the absolute Makefile path" in location_make_verification and
+            "GNU Make 4.2 and 4.4 space-containing absolute Makefile paths passed" in location_make_verification and
             "python3 -m py_compile scripts/check-baseline.py" in location_make_verification and
             "git diff --check" in location_make_verification and
             "`xcodebuild` was unavailable" in location_make_verification and

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHILD_MARKER = "IOS_EMOJI_THROWER_MAKE_SPACE_CHILD"
+
+
+def main():
+    if os.environ.get(CHILD_MARKER) == "1":
+        return
+
+    tracked = subprocess.check_output(
+        ["git", "-C", str(ROOT), "ls-files", "-z"]
+    ).decode().rstrip("\0").split("\0")
+    with tempfile.TemporaryDirectory(prefix="ios-emoji-thrower-make-space-") as temporary:
+        root = Path(temporary)
+        copied = root / "repository with spaces"
+        caller = root / "external caller"
+        shutil.copytree(
+            ROOT,
+            copied,
+            ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.pyo"),
+        )
+        caller.mkdir()
+        subprocess.run(["git", "-C", copied, "init", "-q"], check=True)
+        subprocess.run(
+            ["git", "-C", copied, "add", "-f", "-N", "--", *tracked],
+            check=True,
+        )
+        environment = os.environ.copy()
+        environment[CHILD_MARKER] = "1"
+        subprocess.run(
+            [
+                environment.get("IOS_EMOJI_THROWER_MAKE", "make"),
+                "-f",
+                str(copied / "Makefile"),
+                "check",
+            ],
+            cwd=caller,
+            env=environment,
+            check=True,
+            timeout=180,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -10,6 +10,18 @@ ROOT = Path(__file__).resolve().parents[1]
 CHILD_MARKER = "IOS_EMOJI_THROWER_MAKE_SPACE_CHILD"
 
 
+def run_make(make, arguments, caller, environment):
+    return subprocess.run(
+        [make, *arguments],
+        cwd=caller,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=180,
+    )
+
+
 def main():
     if os.environ.get(CHILD_MARKER) == "1":
         return
@@ -34,18 +46,47 @@ def main():
         )
         environment = os.environ.copy()
         environment[CHILD_MARKER] = "1"
+        make = environment.get("IOS_EMOJI_THROWER_MAKE", "make")
+        repository_makefile = str(copied / "Makefile")
         subprocess.run(
-            [
-                environment.get("IOS_EMOJI_THROWER_MAKE", "make"),
-                "-f",
-                str(copied / "Makefile"),
-                "check",
-            ],
+            [make, "-f", repository_makefile, "check"],
             cwd=caller,
             env=environment,
             check=True,
             timeout=180,
         )
+
+        extra_makefile = root / "extra.mk"
+        extra_makefile.write_text(".PHONY: extra\nextra:\n\t@:\n", encoding="utf-8")
+        replacement_makefile = root / "replacement.mk"
+        replacement_makefile.write_text(".PHONY: check\ncheck:\n\t@echo BYPASSED\n", encoding="utf-8")
+
+        preload_environment = environment.copy()
+        preload_environment["MAKEFILES"] = str(extra_makefile)
+        preload = run_make(make, ["-f", repository_makefile, "check"], caller, preload_environment)
+        if preload.returncode == 0 or "MAKEFILES must be empty" not in preload.stderr:
+            raise RuntimeError("MAKEFILES preload must fail closed")
+
+        overridden = run_make(make, ["-f", repository_makefile, "MAKEFILE_LIST=untrusted", "check"], caller, environment)
+        if overridden.returncode == 0 or "MAKEFILE_LIST must not be overridden" not in overridden.stderr:
+            raise RuntimeError("MAKEFILE_LIST override must fail closed")
+
+        for arguments in (
+            ["-f", str(extra_makefile), "-f", repository_makefile, "check"],
+            ["-f", repository_makefile, "-f", str(extra_makefile), "check"],
+        ):
+            multiple = run_make(make, arguments, caller, environment)
+            if multiple.returncode == 0 or "repository Makefile must be loaded alone" not in multiple.stderr:
+                raise RuntimeError("multiple loaded Makefiles must fail closed")
+
+        replacement = run_make(
+            make,
+            ["-f", repository_makefile, "-f", str(replacement_makefile), "check"],
+            caller,
+            environment,
+        )
+        if replacement.returncode == 0 or "BYPASSED" in replacement.stdout:
+            raise RuntimeError("later recipes must not replace repository verification")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve absolute Makefile roots when the checkout path contains spaces
- fail closed when loaded-file metadata or additional Makefiles could redirect repository verification
- add recursive regressions for spaced paths and Make authority boundaries

## Baseline
GNU Make split space-containing paths exposed through `MAKEFILE_LIST`. Preloaded, overridden, or additional Makefiles also created ambiguous authority over the repository verification recipes.

## Improvements
- derive the root only from a validated, single repository Makefile
- reject `MAKEFILES`, overridden `MAKEFILE_LIST`, multiple loaded Makefiles, and later recipe replacement
- keep SpriteKit gameplay, Xcode project metadata, resources, executable projectile tests, and workflows unchanged

## Validation
- exact head `218e188b82ba20dc096ccc9abc3700444d6a2063` passed `lint`, `test`, `build`, and `check` under GNU Make 4.2.1 and 4.4.1, including copied-checkout spaced-path validation and authority controls
- the unmodified base failed the same spaced absolute-Makefile control
- `git fsck --strict`, `git diff --check`, Python byte-compilation, protected-surface comparison, and Gitleaks passed in a fresh clone
- both final-head macOS baselines passed; they executed the Swift projectile behavior harness and SpriteKit/Xcode baseline for the normal and copied spaced-path checkout
- CodeQL passed for Actions, Python, and Swift

## Risk
Low to moderate for repository behavior because verification now deliberately rejects advanced multi-Makefile invocation patterns. The historical Google API key alert remains open with unknown validity and still requires owner/provider action; this PR does not read, restore, rotate, or claim remediation of that credential.

## Follow-Ups
- resolve or formally dismiss secret-scanning alert #1 only after provider-side revocation or restriction is verified by an authorized owner